### PR TITLE
For streams starting at or very close to availabilityStartTime,

### DIFF
--- a/src/streaming/StreamProcessor.js
+++ b/src/streaming/StreamProcessor.js
@@ -84,8 +84,6 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             trackController.subscribe(Dash.dependencies.RepresentationController.eventList.ENAME_DATA_UPDATE_COMPLETED, bufferController);
             fragmentController.subscribe(MediaPlayer.dependencies.FragmentController.eventList.ENAME_INIT_FRAGMENT_LOADED, bufferController);
 
-            trackController.subscribe(Dash.dependencies.RepresentationController.eventList.ENAME_DATA_UPDATE_COMPLETED, stream);
-
             if (type === "video" || type === "audio" || type === "fragmentedText") {
                 abrController.subscribe(MediaPlayer.dependencies.AbrController.eventList.ENAME_QUALITY_CHANGED, bufferController);
                 abrController.subscribe(MediaPlayer.dependencies.AbrController.eventList.ENAME_QUALITY_CHANGED, trackController);
@@ -143,6 +141,8 @@ MediaPlayer.dependencies.StreamProcessor = function () {
             } else {
                 bufferController.subscribe(MediaPlayer.dependencies.TextController.eventList.ENAME_CLOSED_CAPTIONING_REQUESTED, scheduleController);
             }
+
+            trackController.subscribe(Dash.dependencies.RepresentationController.eventList.ENAME_DATA_UPDATE_COMPLETED, stream);
 
             indexHandler.initialize(this);
             indexHandler.setCurrentTime(playbackController.getStreamStartTime(this.getStreamInfo()));

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -361,11 +361,10 @@ MediaPlayer.dependencies.ScheduleController = function () {
             }
 
             self.metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {currentTime: actualStartTime, presentationStartTime: liveEdgeTime, latency: liveEdgeTime - actualStartTime, clientTimeOffset: self.timelineConverter.getClientTimeOffset()});
-            ready = true;
 
-            if (currentTrackInfo) {
-                startOnReady.call(self);
-            }
+            // ready will checked in onStreamUpdated and scheduling started
+            // based on its value
+            ready = true;
         };
 
 


### PR DESCRIPTION
onLiveEdgeSearchCompleted was called before the currentTrackInfo is valid,
since this is only valid once the segment list has been generated.
The fix is to ensure that the DATE_UPDATE_COMPLETED handler for the
schedule controller is called before that of the stream (by subscribing
them in the correct order). This ensures that the current track info is
valid before the live edge search is started and there is something for
the live edge search completed handler to reference.

Additionally, scheduling is no longer started in the live edge search
complete handler but in the stream updated handler, as (I think) was
intended when that handler was added.
