### PR TITLE
Fix start time calculation when availabilityStartTime is in the future

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -87,7 +87,7 @@ MediaPlayer = function (context) {
         bufferMax = MediaPlayer.dependencies.BufferController.BUFFER_SIZE_REQUIRED,
         useManifestDateHeaderTimeSource = true,
         UTCTimingSources = [],
-        liveDelayFragmentCount = 4,
+        liveDelayFragmentCount = 3,
         usePresentationDelay = false,
 
         isReady = function () {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -346,7 +346,8 @@ MediaPlayer.dependencies.ScheduleController = function () {
             var self = this,
                 liveEdgeTime = e.data.liveEdge,
                 manifestInfo = currentTrackInfo.mediaInfo.streamInfo.manifestInfo,
-                startTime = liveEdgeTime - Math.min((self.playbackController.getLiveDelay(currentTrackInfo.fragmentDuration)), manifestInfo.DVRWindowSize / 2),
+                // startTime should probably never be less than 0
+                startTime = Math.max(0, liveEdgeTime - Math.min((self.playbackController.getLiveDelay(currentTrackInfo.fragmentDuration)), manifestInfo.DVRWindowSize / 2)),
                 request,
                 metrics = self.metricsModel.getMetricsFor("stream"),
                 manifestUpdateInfo = self.metricsExt.getCurrentManifestUpdate(metrics),


### PR DESCRIPTION
1) Change default safety margin back from live edge to match the amount of segments available when starting to play at exactly availabilityStartTime.

2) Ensure live edge start time can never be negative.

This is a short term fix as there are magic numbers scattered all over the place - a real fix needs to be found later.
