### PR TITLE
Last segment error

### DIFF
--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -444,6 +444,21 @@ function MediaPlayer() {
     }
 
     /**
+     * Override duration of the media's playback, in seconds.
+     * Example use: force early payback end if last fragment fails
+     *
+     * @param {string} d - duration in seconds
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setDuration(d) {
+        if (!playbackInitialized) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
+        streamController.setMediaDuration(d);
+    }
+
+    /**
      * Use this method to get the current playhead time as an absolute value, the time in seconds since midnight UTC, Jan 1 1970.
      * Note - this property only has meaning for live streams. If called before play() has begun, it will return a value of NaN.
      *
@@ -1951,6 +1966,7 @@ function MediaPlayer() {
         getVolume: getVolume,
         time: time,
         duration: duration,
+        setDuration: setDuration,
         timeAsUTC: timeAsUTC,
         durationAsUTC: durationAsUTC,
         getActiveStream: getActiveStream,

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -443,11 +443,11 @@ function StreamController() {
         log('MediaSource attached to element.  Waiting on open...');
     }
 
-    function setMediaDuration() {
+    function setMediaDuration(override) {
         var manifestDuration,
             mediaDuration;
 
-        manifestDuration = activeStream.getStreamInfo().manifestInfo.duration;
+        manifestDuration = override || activeStream.getStreamInfo().manifestInfo.duration;
         mediaDuration = mediaSourceController.setDuration(mediaSource, manifestDuration);
         log('Duration successfully set to: ' + mediaDuration);
     }
@@ -779,6 +779,7 @@ function StreamController() {
         initialize: initialize,
         getAutoPlay: getAutoPlay,
         getActiveStreamInfo: getActiveStreamInfo,
+        setMediaDuration: setMediaDuration,
         isStreamActive: isStreamActive,
         isVideoTrackPresent: isVideoTrackPresent,
         getStreamById: getStreamById,


### PR DESCRIPTION
MP-2876: Added API method to manually override manifest duration, and adjusted buffer behaviour to playout in full if within threshold of end duration. Used by SMP to ignore any 404 error from downloading the last segment if within 1s of end. 
