### PR TITLE
SMPHTML-1088 Restart from start of rewind window if drifted out while paused 

### DIFF
--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -368,10 +368,10 @@ function DashHandler(config) {
             log('Getting the request for ' + type + ' time : ' + time);
         }
 
+        updateSegments(representation);
         index = getIndexForSegments(time, representation, timeThreshold);
         //Index may be -1 if getSegments needs to update.  So after getSegments is called and updated then try to get index again.
         if (index < 0) {
-            updateSegments(representation);
             index = getIndexForSegments(time, representation, timeThreshold);
         }
 

--- a/src/dash/DashHandler.js
+++ b/src/dash/DashHandler.js
@@ -370,8 +370,8 @@ function DashHandler(config) {
 
         index = getIndexForSegments(time, representation, timeThreshold);
         //Index may be -1 if getSegments needs to update.  So after getSegments is called and updated then try to get index again.
-        updateSegments(representation);
         if (index < 0) {
+            updateSegments(representation);
             index = getIndexForSegments(time, representation, timeThreshold);
         }
 

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -309,9 +309,9 @@ function PlaybackController() {
 
         if (!DVRWindow) return NaN;
         if (currentTime > DVRWindow.end) {
-            actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start + 0.001);
+            actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start);
         } else if (currentTime < DVRWindow.start) {
-            actualTime = DVRWindow.start + 0.001;
+            actualTime = DVRWindow.start;
         } else {
             return currentTime;
         }

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -308,12 +308,13 @@ function PlaybackController() {
         var actualTime;
 
         if (!DVRWindow) return NaN;
-
-        if ((currentTime >= DVRWindow.start) && (currentTime <= DVRWindow.end)) {
+        if (currentTime > DVRWindow.end) {
+            actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start + 0.001);
+        } else if (currentTime < DVRWindow.start) {
+            actualTime = DVRWindow.start + 0.001;
+        } else {
             return currentTime;
         }
-
-        actualTime = Math.max(DVRWindow.end - streamInfo.manifestInfo.minBufferTime * 2, DVRWindow.start);
 
         return actualTime;
     }


### PR DESCRIPTION
If simulcast playback is resumed at a time outside of the availability window, jump to the nearest edge of the window, rather than always jumping to the live edge.