### PR TITLE
Allow immediate switching when top quality index changes

### DIFF
--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -89,6 +89,7 @@ function ScheduleController(config) {
         nextFragmentRequestRule,
         scheduleWhilePaused,
         lastQualityIndex,
+        topQualityIndex,
         lastInitQuality,
         replaceRequestArray;
 
@@ -96,6 +97,7 @@ function ScheduleController(config) {
         initialPlayback = true;
         lastInitQuality = NaN;
         lastQualityIndex = NaN;
+        topQualityIndex = {};
         replaceRequestArray = [];
         isStopped = false;
         playListMetrics = null;
@@ -185,6 +187,20 @@ function ScheduleController(config) {
         log('Schedule controller stopping for ' + type);
     }
 
+    function hasTopQualityChanged(type, id) {
+
+        topQualityIndex[id] = topQualityIndex[id] || {};
+        let newTopQualityIndex = abrController.getTopQualityIndexFor(type,id);
+
+        if ( topQualityIndex[id][type] != newTopQualityIndex ) {
+            log('Top quality'  + type + ' index has changed from ' + topQualityIndex[id][type] + ' to ' + newTopQualityIndex);
+            topQualityIndex[id][type] = newTopQualityIndex;
+            return true;
+        }
+        return false;
+
+    }
+
     function schedule() {
 
         if (isStopped || isFragmentProcessingInProgress || !bufferController || playbackController.isPaused() && !scheduleWhilePaused) return;
@@ -193,14 +209,14 @@ function ScheduleController(config) {
 
         const isReplacement = replaceRequestArray.length > 0;
         const readyToLoad = bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent());
+        const topQualityChanged = hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id);
 
-        if (readyToLoad || isReplacement) {
+        if (readyToLoad || isReplacement || topQualityChanged) {
             const getNextFragment = function () {
                 if (currentRepresentationInfo.quality !== lastInitQuality) {
                     lastInitQuality = currentRepresentationInfo.quality;
                     bufferController.switchInitData(streamProcessor.getStreamInfo().id, currentRepresentationInfo.quality);
                 } else {
-
                     const request = nextFragmentRequestRule.execute(streamProcessor, replaceRequestArray.shift());
                     if (request) {
                         fragmentModel.executeRequest(request);

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -207,10 +207,10 @@ function ScheduleController(config) {
 
         validateExecutedFragmentRequest();
 
-        let isReplacement, topQualityChanged, readyToLoad;
-        if ( (isReplacement = replaceRequestArray.length > 0) ||
-             (topQualityChanged = hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id)) ||
-             (readyToLoad = bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent()))
+        const isReplacement = replaceRequestArray.length > 0;
+        if ( isReplacement ||
+             hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id) ||
+             bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent())
            ) {
 
             const getNextFragment = function () {

--- a/src/streaming/controllers/ScheduleController.js
+++ b/src/streaming/controllers/ScheduleController.js
@@ -207,11 +207,12 @@ function ScheduleController(config) {
 
         validateExecutedFragmentRequest();
 
-        const isReplacement = replaceRequestArray.length > 0;
-        const readyToLoad = bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent());
-        const topQualityChanged = hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id);
+        let isReplacement, topQualityChanged, readyToLoad;
+        if ( (isReplacement = replaceRequestArray.length > 0) ||
+             (topQualityChanged = hasTopQualityChanged(currentRepresentationInfo.mediaInfo.type, streamProcessor.getStreamInfo().id)) ||
+             (readyToLoad = bufferLevelRule.execute(streamProcessor, type, streamController.isVideoTrackPresent()))
+           ) {
 
-        if (readyToLoad || isReplacement || topQualityChanged) {
             const getNextFragment = function () {
                 if (currentRepresentationInfo.quality !== lastInitQuality) {
                     lastInitQuality = currentRepresentationInfo.quality;


### PR DESCRIPTION
When the max representation available to ABR changes because of updateQuality or Portal Bitrate change, the Buffer Level rule prevents switching because the buffer is larger than the stable bitrate buffer target (12 or 20s). The previous "top quality" target buffer size of (60s) means that any appending to the buffer is suppressed for 48s so the user sees their buffer collapse.

Any change in getTopQualityIndexFor() now allows an immediate update of the rules. This should prevent the buffer near exhausting when quality changes and therefore reduce risk, especially as this happens whenever a user goes fullscreen.

Expensive bufferLevelRule is also not called now if getNextFragment is already triggered by isReplacement or topQualityChanged.