### PR TITLE
Xhr fragment timeout

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,6 +242,8 @@ declare namespace dashjs {
         removeAllABRCustomRule(): void;
         getLowLatencyEnabled(): boolean;
         setLowLatencyEnabled(value: boolean): void;
+        setFragmentRequestTimeout(value: number): void;
+        getFragmentRequestTimeout(): number;
         enableLowLatencyCatchUp(value: boolean): void;
         getLowLatencyMinDrift(): number;
         setLowLatencyMinDrift(value: number): void;

--- a/src/streaming/FragmentLoader.js
+++ b/src/streaming/FragmentLoader.js
@@ -54,7 +54,8 @@ function FragmentLoader(config) {
             mediaPlayerModel: config.mediaPlayerModel,
             requestModifier: config.requestModifier,
             boxParser: boxParser,
-            useFetch: config.mediaPlayerModel.getLowLatencyEnabled()
+            useFetch: config.mediaPlayerModel.getLowLatencyEnabled(),
+            requestTimeout: config.mediaPlayerModel.getFragmentRequestTimeout()
         });
     }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1529,6 +1529,26 @@ function MediaPlayer() {
     }
 
     /**
+     * Sets the request timeout (in miliseconds) for requests sent via the HTTPLoader
+     * @param {number} value
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setFragmentRequestTimeout(value) {
+        mediaPlayerModel.setFragmentRequestTimeout(value);
+    }
+
+    /**
+     * Gets the request timeout (in miliseconds) for requests sent via the HTTPLoader
+     * @return {number} The active request timeout in miliseconds
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function getFragmentRequestTimeout() {
+        return mediaPlayerModel.getFragmentRequestTimeout();
+    }
+
+    /**
      * <p>Allows you to set a scheme and server source for UTC live edge detection for dynamic streams.
      * If UTCTiming is defined in the manifest, it will take precedence over any time source manually added.</p>
      * <p>If you have exposed the Date header, use the method {@link module:MediaPlayer#clearDefaultUTCTimingSources clearDefaultUTCTimingSources()}.
@@ -3223,6 +3243,8 @@ function MediaPlayer() {
         getSmallGapLimit: getSmallGapLimit,
         setLowLatencyEnabled: setLowLatencyEnabled,
         getLowLatencyEnabled: getLowLatencyEnabled,
+        setFragmentRequestTimeout: setFragmentRequestTimeout,
+        getFragmentRequestTimeout: getFragmentRequestTimeout,
         setCatchUpPlaybackRate: setCatchUpPlaybackRate,
         getCatchUpPlaybackRate: getCatchUpPlaybackRate,
         setLowLatencyMinDrift: setLowLatencyMinDrift,

--- a/src/streaming/models/MediaPlayerModel.js
+++ b/src/streaming/models/MediaPlayerModel.js
@@ -109,6 +109,7 @@ function MediaPlayerModel() {
         ABRStrategy,
         useDefaultABRRules,
         xhrWithCredentials,
+        fragmentRequestTimeout,
         fastSwitchEnabled,
         customABRRule,
         movingAverageMethod,
@@ -162,6 +163,7 @@ function MediaPlayerModel() {
         xhrWithCredentials = {
             default: DEFAULT_XHR_WITH_CREDENTIALS
         };
+        fragmentRequestTimeout = 0;
         customABRRule = [];
         movingAverageMethod = Constants.MOVING_AVERAGE_SLIDING_WINDOW;
         lowLatencyEnabled = false;
@@ -622,6 +624,14 @@ function MediaPlayerModel() {
         return DEFAULT_UTC_TIMING_SOURCE;
     }
 
+    function setFragmentRequestTimeout(value) {
+        fragmentRequestTimeout = value;
+    }
+
+    function getFragmentRequestTimeout() {
+        return fragmentRequestTimeout;
+    }
+
     function reset() {
         //TODO need to figure out what props to persist across sessions and which to reset if any.
         //setup();
@@ -705,6 +715,8 @@ function MediaPlayerModel() {
         setKeepProtectionMediaKeys: setKeepProtectionMediaKeys,
         getKeepProtectionMediaKeys: getKeepProtectionMediaKeys,
         getDefaultUtcTimingSource: getDefaultUtcTimingSource,
+        setFragmentRequestTimeout: setFragmentRequestTimeout,
+        getFragmentRequestTimeout: getFragmentRequestTimeout,
         reset: reset
     };
 

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -243,7 +243,15 @@ function HTTPLoader(cfg) {
             }
         };
 
-        const ontimeout = function () {
+        const ontimeout = function (event) {
+            let timeoutMessage;
+            if (event.lengthComputable) {
+                let percentageComplete = (event.loaded / event.total) * 100;
+                timeoutMessage = 'Request timeout: loaded: ' + event.loaded + ', out of: ' + event.total + ' : ' + percentageComplete.toFixed(3) + '% Completed';
+            } else {
+                timeoutMessage = 'Request timeout: non-computable download size';
+            }
+            logger.warn(timeoutMessage);
         };
 
         let loader;

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -52,6 +52,7 @@ function HTTPLoader(cfg) {
     const requestModifier = cfg.requestModifier;
     const boxParser = cfg.boxParser;
     const useFetch = cfg.useFetch || false;
+    const requestTimeout = cfg.requestTimeout || 0;
 
     let logger,
         instance,
@@ -242,6 +243,9 @@ function HTTPLoader(cfg) {
             }
         };
 
+        const ontimeout = function () {
+        };
+
         let loader;
         if (useFetch && window.fetch && request.responseType === 'arraybuffer' && request.type === HTTPRequest.MEDIA_SEGMENT_TYPE) {
             loader = FetchLoader(context).create({
@@ -269,7 +273,9 @@ function HTTPLoader(cfg) {
             onerror: onloadend,
             progress: progress,
             onabort: onabort,
-            loader: loader
+            ontimeout: ontimeout,
+            loader: loader,
+            timeout: requestTimeout
         };
 
         // Adds the ability to delay single fragment loading time to control buffer.

--- a/src/streaming/net/XHRLoader.js
+++ b/src/streaming/net/XHRLoader.js
@@ -74,6 +74,8 @@ function XHRLoader(cfg) {
         xhr.onerror = httpRequest.onerror;
         xhr.onprogress = httpRequest.progress;
         xhr.onabort = httpRequest.onabort;
+        xhr.ontimeout = httpRequest.ontimeout;
+        xhr.timeout = httpRequest.timeout;
 
         xhr.send();
 

--- a/test/unit/mocks/MediaPlayerModelMock.js
+++ b/test/unit/mocks/MediaPlayerModelMock.js
@@ -205,6 +205,7 @@ class MediaPlayerModelMock {
         this.xhrWithCredentials = {
             default: DEFAULT_XHR_WITH_CREDENTIALS
         };
+        this.fragmentRequestTimeout = 0;
         this.customABRRule = [];
 
         this.retryAttempts = {
@@ -552,6 +553,14 @@ class MediaPlayerModelMock {
 
     getCatchUpPlaybackRate() {
         return this.lowLatencyCatchUpPlaybackRate;
+    }
+
+    setFragmentRequestTimeout(value) {
+        this.fragmentRequestTimeout = value;
+    }
+
+    getFragmentRequestTimeout() {
+        return this.fragmentRequestTimeout;
     }
 
     reset() {

--- a/test/unit/streaming.net.XHRLoader.js
+++ b/test/unit/streaming.net.XHRLoader.js
@@ -144,4 +144,18 @@ describe('XHRLoader', function () {
         sinon.assert.notCalled(callbackAbort);
         expect(callbackError.calledBefore(callbackCompleted)).to.be.true; // jshint ignore:line
     });
+
+    it('should set timeout on the sending XHR request', () => {
+        xhrLoader = XHRLoader(context).create({
+            requestModifier: requestModifier
+        });
+        const request = {
+            request: {
+                checkExistenceOnly: true
+            },
+            timeout: 100
+        };
+        xhrLoader.load(request);
+        expect(request.response.timeout).to.be.equal(100);
+    });
 });


### PR DESCRIPTION
Reopened the PR for adding a fragment timeout to the xhr requests, configurable on the `mediaplayer` interface.