### PR TITLE
Refresh Manifest Media Player Callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -209,6 +209,7 @@ declare namespace dashjs {
         getBandwidthSafetyFactor(): number;
         setAbandonLoadTimeout(value: number): void;
         retrieveManifest(url: string, callback: (manifest: object | null, error: any) => void): void;
+        refreshManifest(callback: (manifest: object | null, error: any) => void): void;
         addUTCTimingSource(schemeIdUri: string, value: string): void;
         removeUTCTimingSource(schemeIdUri: string, value: string): void;
         clearDefaultUTCTimingSources(): void;

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2805,27 +2805,18 @@ function MediaPlayer() {
      */
     function refreshManifest(callback) {
 
-        let removeCallbacks;
+        let self = this;
 
-        let callbackWrapperSuccess = function (e) {
-            if (callback) callback(e.manifest);
-            if (removeCallbacks) removeCallbacks();
-        };
-
-        let callbackWrapperError = function (e) {
-            if (e.error.code === Errors.DOWNLOAD_ERROR_ID_MANIFEST_CODE) {
-                if (callback) callback(e);
-                if (removeCallbacks) removeCallbacks();
+        const handler = function (e) {
+            if (!e.error) {
+                callback(e.manifest);
+            } else {
+                callback(null, e.error);
             }
+            eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
         };
 
-        removeCallbacks = function () {
-            off(Events.INTERNAL_MANIFEST_LOADED, callbackWrapperSuccess);
-            off(Events.ERROR, callbackWrapperError);
-        };
-
-        on(Events.INTERNAL_MANIFEST_LOADED, callbackWrapperSuccess);
-        on(Events.ERROR, callbackWrapperError);
+        eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);
         streamController.refreshManifest();
     }
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2808,7 +2808,7 @@ function MediaPlayer() {
         let removeCallbacks;
 
         let callbackWrapperSuccess = function (e) {
-            if (callback) callback(e);
+            if (callback) callback(e.manifest);
             if (removeCallbacks) removeCallbacks();
         };
 

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2805,7 +2805,6 @@ function MediaPlayer() {
      */
     function refreshManifest(callback) {
 
-        let refreshTimer;
         let removeCallbacks;
 
         let callbackWrapperSuccess = function (e) {
@@ -2821,9 +2820,6 @@ function MediaPlayer() {
         };
 
         removeCallbacks = function () {
-            if (refreshTimer) {
-                clearTimeout(refreshTimer);
-            }
             off(Events.INTERNAL_MANIFEST_LOADED, callbackWrapperSuccess);
             off(Events.ERROR, callbackWrapperError);
         };

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2824,17 +2824,13 @@ function MediaPlayer() {
             if (refreshTimer) {
                 clearTimeout(refreshTimer);
             }
-            off(Events.MANIFEST_UPDATED, callbackWrapperSuccess);
+            off(Events.INTERNAL_MANIFEST_LOADED, callbackWrapperSuccess);
             off(Events.ERROR, callbackWrapperError);
         };
 
-        on(Events.MANIFEST_UPDATED, callbackWrapperSuccess);
+        on(Events.INTERNAL_MANIFEST_LOADED, callbackWrapperSuccess);
         on(Events.ERROR, callbackWrapperError);
         streamController.refreshManifest();
-
-        refreshTimer = setTimeout(function () {
-            callbackWrapperError({error: {code: Errors.DOWNLOAD_ERROR_ID_MANIFEST_CODE}});
-        }, 2000);
     }
 
     /**


### PR DESCRIPTION
Added a completion callback to the `MediaPlayer.refreshManifest` method to pass the manifest object reference on success (or error info object on error) to the callback method.