### PR TITLE
Add guard around httpRequest.response

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -156,7 +156,7 @@ function HTTPLoader(cfg) {
                 requests.splice(requests.indexOf(httpRequest), 1);
             }
 
-            if (httpRequest && httpRequest.response && httpRequest.response.status >= 200 && httpRequest.response.status <= 299) {
+            if (httpRequest.response && httpRequest.response.status >= 200 && httpRequest.response.status <= 299) {
                 const mismatchCheckType = httpRequest.request && httpRequest.request.mediaType !== 'fragmentedText';
                 if (mismatchCheckType && hasContentLengthMismatch(httpRequest.response)) {
                     handleLoaded(false);

--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -156,7 +156,7 @@ function HTTPLoader(cfg) {
                 requests.splice(requests.indexOf(httpRequest), 1);
             }
 
-            if (httpRequest.response.status >= 200 && httpRequest.response.status <= 299) {
+            if (httpRequest && httpRequest.response && httpRequest.response.status >= 200 && httpRequest.response.status <= 299) {
                 const mismatchCheckType = httpRequest.request && httpRequest.request.mediaType !== 'fragmentedText';
                 if (mismatchCheckType && hasContentLengthMismatch(httpRequest.response)) {
                     handleLoaded(false);


### PR DESCRIPTION
There have been observations of streams failing with `"TypeError: undefined is not an object (evaluating 'httpRequest.response.status')"` on certain WebKit based browsers. 

When this happens it appears that `xhr.send()` is calling `onloadend` synchronously before setting `httpRequest.response = xhr;` in [XHRLoader](https://github.com/bbc/dash.js/blob/smp-v2.9/src/streaming/net/XHRLoader.js#L82).