### PR TITLE
Start at the beginning of DVRWindow when live edge is past duration

### DIFF
--- a/test/unit/mocks/AdapterMock.js
+++ b/test/unit/mocks/AdapterMock.js
@@ -114,6 +114,12 @@ function AdapterMock () {
     this.convertDataToRepresentationInfo = function () {
         return null;
     };
+
+    this._mockDuration = NaN;
+
+    this.getDuration = function () {
+        return this._mockDuration;
+    };
 }
 
 export default AdapterMock;

--- a/test/unit/streaming.controllers.PlaybackControllers.js
+++ b/test/unit/streaming.controllers.PlaybackControllers.js
@@ -521,5 +521,16 @@ describe('PlaybackController', function () {
             streamMock.initialize(dynamicStreamInfo);
             eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: liveStartTime});
         });
+
+        it('should start a dynamic stream with a duration at DVR start if the live point exceeds duration', function (done) {
+            doneFn = done;
+
+            adapterMock._mockDuration = 100;
+            expectedSeekTime = dvrWindowRange.start;
+
+            playbackController.initialize(dynamicStreamInfo);
+            streamMock.initialize(dynamicStreamInfo);
+            eventBus.trigger(Events.STREAM_INITIALIZED, {liveStartTime: 120});
+        });
     });
 });


### PR DESCRIPTION
When a live stream ends, it's not necessarily going to change to static – it can still be dynamic, it will just have a mediaPresentationDuration attribute. This case isn't handled in the start time logic.

When starting a stream with a duration that shorter than the liveEdge (i.e. you're starting after it's ended + latency), this will set the start time to the beginning of the DVR window. This makes an still dynamic ended event act somewhat like one that's changed to static.