### PR TITLE
[COMPAT] Use unnamed capture groups

### DIFF
--- a/src/streaming/models/CmsdModel.js
+++ b/src/streaming/models/CmsdModel.js
@@ -197,7 +197,7 @@ function CmsdModel() {
         for (let i = headers.length - 1; i >= 0; i--) {
             const header = headers[i];
             let m = header.match(/^([^:]*):\s*(.*)$/);
-            if (m && m[1] && m[2]) {
+            if (m) {
                 // Note: in modern browsers, the header names are returned in all lower case
                 let key = m[1].toLowerCase(),
                     value = m[2];
@@ -215,7 +215,6 @@ function CmsdModel() {
                         break;
                 }
             }
-        }
 
         // Get object type
         let ot = OBJECT_TYPES.STREAM;

--- a/src/streaming/models/CmsdModel.js
+++ b/src/streaming/models/CmsdModel.js
@@ -196,11 +196,11 @@ function CmsdModel() {
         // Ge in reverse order in order to consider only last CMSD-Dynamic header
         for (let i = headers.length - 1; i >= 0; i--) {
             const header = headers[i];
-            let m = header.match(/^(?<key>[^:]*):\s*(?<value>.*)$/);
-            if (m && m.groups) {
+            let m = header.match(/^([^:]*):\s*(.*)$/);
+            if (m && m[1] && m[2]) {
                 // Note: in modern browsers, the header names are returned in all lower case
-                let key = m.groups.key.toLowerCase(),
-                    value = m.groups.value;
+                let key = m[1].toLowerCase(),
+                    value = m[2];
                 switch (key) {
                     case CMSD_STATIC_RESPONSE_FIELD_NAME:
                         staticParams = _parseCMSDStatic(value);


### PR DESCRIPTION
## What?

Replace use of named capture groups with unnamed ones.

## Why?

Named capture groups is an ES2018 feature that isn't trivial to polyfill.