### PR TITLE
Add `portalScale` and `portalMinimum`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1094,6 +1094,8 @@ declare namespace dashjs {
                 useDeadTimeLatency?: boolean;
                 limitBitrateByPortal?: boolean;
                 usePixelRatioInLimitBitrateByPortal?: boolean;
+                portalScale?: number;
+                portalMinimum?: number;
                 maxBitrate?: {
                     audio?: number;
                     video?: number;

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -201,6 +201,8 @@ import Events from './events/Events';
  *                useDeadTimeLatency: true,
  *                limitBitrateByPortal: false,
  *                usePixelRatioInLimitBitrateByPortal: false,
+ *                portalScale: 1,
+ *                portalMinimum: 0,
  *                maxBitrate: { audio: -1, video: -1 },
  *                minBitrate: { audio: -1, video: -1 },
  *                maxRepresentationRatio: { audio: 1, video: 1 },
@@ -600,6 +602,10 @@ import Events from './events/Events';
  * If true, the size of the video portal will limit the max chosen video resolution.
  * @property {boolean} [usePixelRatioInLimitBitrateByPortal=false]
  * Sets whether to take into account the device's pixel ratio when defining the portal dimensions.
+ * @property {number} [portalScale=1]
+ * Scales the size of the video portal used to limit the max video resolution. Square root scale.
+ * @property {number} [portalMinimum=0]
+ * Limits the min bandwidth that video playback can go down to depending on the portal size.
  *
  * Useful on, for example, retina displays.
  * @property {module:Settings~AudioVideoSettings} [maxBitrate={audio: -1, video: -1}]
@@ -975,7 +981,7 @@ function Settings() {
                 limitBitrateByPortal: false,
                 usePixelRatioInLimitBitrateByPortal: false,
                 portalScale: 1,
-                portalMinimum: null,
+                portalMinimum: 0,
                 maxBitrate: {
                     audio: -1,
                     video: -1

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -975,6 +975,7 @@ function Settings() {
                 limitBitrateByPortal: false,
                 usePixelRatioInLimitBitrateByPortal: false,
                 portalScale: 1,
+                portalMinimum: null,
                 maxBitrate: {
                     audio: -1,
                     video: -1

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -974,6 +974,7 @@ function Settings() {
                 useDeadTimeLatency: true,
                 limitBitrateByPortal: false,
                 usePixelRatioInLimitBitrateByPortal: false,
+                portalScale: 1,
                 maxBitrate: {
                     audio: -1,
                     video: -1

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -536,8 +536,6 @@ function AbrController() {
         const scaledWidth = elementWidth * Math.sqrt(portalScale);
         const scaledHeight = elementHeight * Math.sqrt(portalScale);
 
-        debugger;
-
         if (scaledWidth > 0 && scaledHeight > 0) {
             while (
                 newIdx > 0 &&

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -529,6 +529,7 @@ function AbrController() {
         }
 
         const portalScale = settings.get().streaming.abr.portalScale || 1;
+        const portalLimitMinimum = settings.get().streaming.abr.portalMinimum || 0;
         const streamInfo = streamProcessorDict[streamId][type].getStreamInfo();
         const representation = adapter.getAdaptationForType(streamInfo.index, type, streamInfo).Representation_asArray;
         let newIdx = idx;
@@ -542,7 +543,8 @@ function AbrController() {
                 newIdx > 0 &&
                 representation[newIdx] &&
                 scaledWidth < representation[newIdx].width &&
-                scaledWidth - representation[newIdx - 1].width < representation[newIdx].width - scaledWidth) {
+                scaledWidth - representation[newIdx - 1].width < representation[newIdx].width - scaledWidth &&
+                representation[newIdx - 1].bandwidth >= portalLimitMinimum * 1000) {
                 newIdx = newIdx - 1;
             }
 

--- a/src/streaming/controllers/AbrController.js
+++ b/src/streaming/controllers/AbrController.js
@@ -527,16 +527,22 @@ function AbrController() {
         if (!windowResizeEventCalled) {
             setElementSize();
         }
+
+        const portalScale = settings.get().streaming.abr.portalScale || 1;
         const streamInfo = streamProcessorDict[streamId][type].getStreamInfo();
         const representation = adapter.getAdaptationForType(streamInfo.index, type, streamInfo).Representation_asArray;
         let newIdx = idx;
+        const scaledWidth = elementWidth * Math.sqrt(portalScale);
+        const scaledHeight = elementHeight * Math.sqrt(portalScale);
 
-        if (elementWidth > 0 && elementHeight > 0) {
+        debugger;
+
+        if (scaledWidth > 0 && scaledHeight > 0) {
             while (
                 newIdx > 0 &&
                 representation[newIdx] &&
-                elementWidth < representation[newIdx].width &&
-                elementWidth - representation[newIdx - 1].width < representation[newIdx].width - elementWidth) {
+                scaledWidth < representation[newIdx].width &&
+                scaledWidth - representation[newIdx - 1].width < representation[newIdx].width - scaledWidth) {
                 newIdx = newIdx - 1;
             }
 

--- a/test/unit/mocks/AdapterMock.js
+++ b/test/unit/mocks/AdapterMock.js
@@ -62,41 +62,17 @@ function AdapterMock() {
     };
 
     this.getAdaptationForType = function () {
+        const representation = [
+            { width: 500, bitrate: 1000000 },
+            { width: 750, bitrate: 2000000 },
+            { width: 900, bitrate: 3000000 },
+            { width: 900, bitrate: 4000000 },
+            { width: 900, bitrate: 5000000 }
+        ]
+
         return {
-            Representation: [
-                {
-                    width: 500
-                },
-                {
-                    width: 750
-                },
-                {
-                    width: 900
-                },
-                {
-                    width: 900
-                },
-                {
-                    width: 900
-                }
-            ],
-            Representation_asArray: [
-                {
-                    width: 500
-                },
-                {
-                    width: 750
-                },
-                {
-                    width: 900
-                },
-                {
-                    width: 900
-                },
-                {
-                    width: 900
-                }
-            ]
+            Representation: [...representation],
+            Representation_asArray: [...representation]
         };
     };
 

--- a/test/unit/mocks/AdapterMock.js
+++ b/test/unit/mocks/AdapterMock.js
@@ -63,11 +63,11 @@ function AdapterMock() {
 
     this.getAdaptationForType = function () {
         const representation = [
-            { width: 500, bitrate: 1000000 },
-            { width: 750, bitrate: 2000000 },
-            { width: 900, bitrate: 3000000 },
-            { width: 900, bitrate: 4000000 },
-            { width: 900, bitrate: 5000000 }
+            { width: 500, bandwidth: 1000000 },
+            { width: 750, bandwidth: 2000000 },
+            { width: 900, bandwidth: 3000000 },
+            { width: 900, bandwidth: 4000000 },
+            { width: 900, bandwidth: 5000000 }
         ]
 
         return {

--- a/test/unit/streaming.controllers.AbrController.js
+++ b/test/unit/streaming.controllers.AbrController.js
@@ -270,7 +270,7 @@ describe('AbrController', function () {
         expect(minAllowedIndex).to.be.equal(0);
     });
 
-    it('should return the appropriate max allowed index for the portal size', function () {
+    it('should return the appropriate max allowed index for the portal scale', function () {
         const mediaInfo = streamProcessor.getMediaInfo();
 
         mediaInfo.streamInfo = streamProcessor.getStreamInfo();
@@ -290,12 +290,12 @@ describe('AbrController', function () {
 
         expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(1)
 
-        s.streaming.abr.portalSize = 2
+        s.streaming.abr.portalScale = 2
         settings.update(s)
 
         expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(4)
 
-        s.streaming.abr.portalSize = 0.2
+        s.streaming.abr.portalScale = 0.2
         settings.update(s)
 
         expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(0)

--- a/test/unit/streaming.controllers.AbrController.js
+++ b/test/unit/streaming.controllers.AbrController.js
@@ -270,6 +270,37 @@ describe('AbrController', function () {
         expect(minAllowedIndex).to.be.equal(0);
     });
 
+    it('should return the appropriate max allowed index for the portal size', function () {
+        const mediaInfo = streamProcessor.getMediaInfo();
+
+        mediaInfo.streamInfo = streamProcessor.getStreamInfo();
+        mediaInfo.representationCount = 5;
+        mediaInfo.type = Constants.VIDEO;
+        abrCtrl.updateTopQualityIndex(mediaInfo);
+
+        const s = { streaming: { abr: { limitBitrateByPortal: true } } };
+        const streamId = streamProcessor.getStreamInfo().id;
+        settings.update(s);
+
+        videoModelMock.width = 1000
+
+        expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(4)
+
+        videoModelMock.width = 800
+
+        expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(1)
+
+        s.streaming.abr.portalSize = 2
+        settings.update(s)
+
+        expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(4)
+
+        s.streaming.abr.portalSize = 0.2
+        settings.update(s)
+
+        expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(0)
+    })
+
     it('should configure initial bitrate for video type', function () {
         domStorageMock.setSavedBitrateSettings(Constants.VIDEO, 50);
 

--- a/test/unit/streaming.controllers.AbrController.js
+++ b/test/unit/streaming.controllers.AbrController.js
@@ -319,6 +319,7 @@ describe('AbrController', function () {
         expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(0)
 
         s.streaming.abr.portalMinimum = 2000
+        settings.update(s)
 
         expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(1)
     })

--- a/test/unit/streaming.controllers.AbrController.js
+++ b/test/unit/streaming.controllers.AbrController.js
@@ -301,6 +301,28 @@ describe('AbrController', function () {
         expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(0)
     })
 
+    it('should limit the min allowed bitrate for the portal scale', function () {
+        const mediaInfo = streamProcessor.getMediaInfo();
+
+        mediaInfo.streamInfo = streamProcessor.getStreamInfo();
+        mediaInfo.representationCount = 5;
+        mediaInfo.type = Constants.VIDEO;
+        abrCtrl.updateTopQualityIndex(mediaInfo);
+
+        const s = { streaming: { abr: { limitBitrateByPortal: true } } };
+        const streamId = streamProcessor.getStreamInfo().id;
+        settings.update(s);
+
+        s.streaming.abr.portalScale = 0.2
+        settings.update(s)
+
+        expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(0)
+
+        s.streaming.abr.portalMinimum = 2000
+
+        expect(abrCtrl.getMaxAllowedIndexFor(Constants.VIDEO, streamId)).to.be.equal(1)
+    })
+
     it('should configure initial bitrate for video type', function () {
         domStorageMock.setSavedBitrateSettings(Constants.VIDEO, 50);
 


### PR DESCRIPTION
## What

Add `portalScale` to scale the portal size used to calculate the max bandwidth given a view portal's dimensions.
Add `portalMinimum` to define a limit on how far `portalScale` can take the bandwidth down.

## How

Impl unit tests, update types, update JSDoc.