### PR TITLE
`setMediaDuration` MSE duration override

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1344,6 +1344,8 @@ declare namespace dashjs {
 
         getInitialMediaSettingsFor(type: MediaType): MediaSettings;
 
+        setMediaDuration(duration: number): void;
+
         setCurrentTrack(track: MediaInfo): void;
 
         addABRCustomRule(type: string, rulename: string, rule: object): void;
@@ -2290,6 +2292,8 @@ declare namespace dashjs {
         reset(): void;
 
         getStreams(): any[];
+
+        setMediaDuration(duration: number): void;
     }
 
     export interface TimeSyncController {

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2449,7 +2449,6 @@ function MediaPlayer() {
     }
 
     instance = {
-        setMediaDuration,
         initialize,
         setConfig,
         on,
@@ -2511,6 +2510,7 @@ function MediaPlayer() {
         getCurrentTrackFor,
         setInitialMediaSettingsFor,
         getInitialMediaSettingsFor,
+        setMediaDuration,
         setCurrentTrack,
         addABRCustomRule,
         removeABRCustomRule,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -2440,7 +2440,16 @@ function MediaPlayer() {
         }
     }
 
+    function setMediaDuration (duration) {
+        if (!playbackInitialized) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
+
+        streamController.setMediaDuration(duration)
+    }
+
     instance = {
+        setMediaDuration,
         initialize,
         setConfig,
         on,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -943,6 +943,22 @@ function MediaPlayer() {
         return _getAsUTC(duration());
     }
 
+    /**
+     * Use this method to override the duration of the current MediaSource object.
+     * 
+     * @throws {@link module:MediaPlayer~PLAYBACK_NOT_INITIALIZED_ERROR PLAYBACK_NOT_INITIALIZED_ERROR} if called before initializePlayback function
+     * @param {number} duration
+     * @memberof module:MediaPlayer
+     * @instance
+     */
+    function setMediaDuration (duration) {
+        if (!playbackInitialized) {
+            throw PLAYBACK_NOT_INITIALIZED_ERROR;
+        }
+
+        streamController.setMediaDuration(duration)
+    }
+
     /*
     ---------------------------------------------------------------------------
 
@@ -2438,14 +2454,6 @@ function MediaPlayer() {
             playbackInitialized = true;
             logger.info('Playback Initialized');
         }
-    }
-
-    function setMediaDuration (duration) {
-        if (!playbackInitialized) {
-            throw PLAYBACK_NOT_INITIALIZED_ERROR;
-        }
-
-        streamController.setMediaDuration(duration)
     }
 
     instance = {

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -465,7 +465,7 @@ function StreamController() {
             mediaSource.removeEventListener('sourceopen', _onMediaSourceOpen);
             mediaSource.removeEventListener('webkitsourceopen', _onMediaSourceOpen);
 
-            _setMediaDuration();
+            setMediaDuration();
             const dvrInfo = dashMetrics.getCurrentDVRInfo();
             mediaSourceController.setSeekable(dvrInfo.range.start, dvrInfo.range.end);
             if (streamActivated) {
@@ -1037,7 +1037,7 @@ function StreamController() {
      * @param {number} duration
      * @private
      */
-    function _setMediaDuration(duration) {
+    function setMediaDuration(duration) {
         const manifestDuration = duration ? duration : getActiveStreamInfo().manifestInfo.duration;
         mediaSourceController.setDuration(manifestDuration);
     }
@@ -1440,7 +1440,7 @@ function StreamController() {
 
     function _onManifestValidityChanged(e) {
         if (!isNaN(e.newDuration)) {
-            _setMediaDuration(e.newDuration);
+            setMediaDuration(e.newDuration);
         }
     }
 
@@ -1623,6 +1623,7 @@ function StreamController() {
         getActiveStream,
         getInitialPlayback,
         getAutoPlay,
+        setMediaDuration,
         reset
     };
 

--- a/test/unit/mocks/StreamControllerMock.js
+++ b/test/unit/mocks/StreamControllerMock.js
@@ -93,6 +93,8 @@ class StreamControllerMock {
         return true;
     }
 
+    setMediaDuration() {}
+
 }
 
 export default StreamControllerMock;

--- a/test/unit/streaming.MediaPlayer.js
+++ b/test/unit/streaming.MediaPlayer.js
@@ -184,6 +184,9 @@ describe('MediaPlayer', function () {
                 expect(player.durationAsUTC).to.throw(PLAYBACK_NOT_INITIALIZED_ERROR);
             });
 
+            it('Method setDuration should throw an exception', function () {
+                expect(player.setDuration()).to.throw(PLAYBACK_NOT_INITIALIZED_ERROR);
+            });
         });
 
         describe('When it is initialized', function () {
@@ -376,6 +379,11 @@ describe('MediaPlayer', function () {
                 duration = player.duration();
                 expect(duration).to.equal(4);
             });
+
+            it('Method duration should set duration of playback', function () {
+                player.setDuration(15)
+                expect(player.duration()).to.equal(15)
+            })
         });
     });
 

--- a/test/unit/streaming.MediaPlayer.js
+++ b/test/unit/streaming.MediaPlayer.js
@@ -14,6 +14,7 @@ import Settings from '../../src/core/Settings';
 import ABRRulesCollection from '../../src/streaming/rules/abr/ABRRulesCollection';
 import CustomParametersModel from '../../src/streaming/models/CustomParametersModel';
 
+const sinon = require('sinon');
 const expect = require('chai').expect;
 const ELEMENT_NOT_ATTACHED_ERROR = 'You must first call attachView() to set the video element before calling this method';
 const PLAYBACK_NOT_INITIALIZED_ERROR = 'You must first call initialize() and set a valid source and view before calling this method';
@@ -184,8 +185,8 @@ describe('MediaPlayer', function () {
                 expect(player.durationAsUTC).to.throw(PLAYBACK_NOT_INITIALIZED_ERROR);
             });
 
-            it('Method setDuration should throw an exception', function () {
-                expect(player.setDuration()).to.throw(PLAYBACK_NOT_INITIALIZED_ERROR);
+            it('Method setMediaDuration should throw an exception', function () {
+                expect(player.setMediaDuration).to.throw(PLAYBACK_NOT_INITIALIZED_ERROR);
             });
         });
 
@@ -380,9 +381,15 @@ describe('MediaPlayer', function () {
                 expect(duration).to.equal(4);
             });
 
-            it('Method duration should set duration of playback', function () {
-                player.setDuration(15)
-                expect(player.duration()).to.equal(15)
+            it('Method setMediaDuration should call through to streamController', function () {
+                const oldSetMediaDuration = streamControllerMock.setMediaDuration
+
+                streamControllerMock.setMediaDuration = sinon.spy()
+                player.setMediaDuration(15)
+
+                sinon.assert.calledWith(streamControllerMock.setMediaDuration, 15)
+
+                streamControllerMock.setMediaDuration = oldSetMediaDuration
             })
         });
     });

--- a/test/unit/streaming.MediaPlayer.js
+++ b/test/unit/streaming.MediaPlayer.js
@@ -382,14 +382,13 @@ describe('MediaPlayer', function () {
             });
 
             it('Method setMediaDuration should call through to streamController', function () {
-                const oldSetMediaDuration = streamControllerMock.setMediaDuration
+                sinon.spy(streamControllerMock, 'setMediaDuration');
 
-                streamControllerMock.setMediaDuration = sinon.spy()
-                player.setMediaDuration(15)
+                player.setMediaDuration(15);
 
-                sinon.assert.calledWith(streamControllerMock.setMediaDuration, 15)
+                expect(streamControllerMock.setMediaDuration.calledWith(15)).to.be.true;
 
-                streamControllerMock.setMediaDuration = oldSetMediaDuration
+                streamControllerMock.setMediaDuration.restore();
             })
         });
     });


### PR DESCRIPTION
## What

Add capability to override the duration of the MediaSource object

## Why

Some MSE devices do not support `clearLiveSeekableRange` and `setLiveSeekableRange`.