### PR TITLE
Refresh manifest

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2627,6 +2627,8 @@ declare namespace dashjs {
 
         getDefaultUtcTimingSource(): UTCTiming;
 
+        refreshManifest(callback: (manifest: object | null, error: any) => void): void;
+
         reset(): void;
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1249,6 +1249,8 @@ declare namespace dashjs {
 
         attachSource(urlOrManifest: string | object, startTime?: number | string): void;
 
+        refreshManifest(callback: (manifest: object | null, error: unknown) => void): void;
+
         isReady(): boolean;
 
         preload(): void;
@@ -2626,8 +2628,6 @@ declare namespace dashjs {
         getXHRWithCredentialsForType(type: string): object;
 
         getDefaultUtcTimingSource(): UTCTiming;
-
-        refreshManifest(callback: (manifest: object | null, error: any) => void): void;
 
         reset(): void;
     }

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1935,23 +1935,20 @@ function MediaPlayer() {
         }
 
         if(!isReady()) {
-            callback(null, {
-                error: SOURCE_NOT_ATTACHED_ERROR
-            });
-
-            return;
+            return callback(null, SOURCE_NOT_ATTACHED_ERROR);
         }
 
         let self = this;
 
         if (typeof callback === 'function') {
             const handler = function (e) {
-                if (!e.error) {
-                    callback(e.manifest);
-                } else {
-                    callback(null, e.error);
-                }
                 eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
+
+                if (e.error) {
+                    return callback(null, e.error);
+                }
+
+                callback(e.manifest);
             };
 
             eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -945,7 +945,7 @@ function MediaPlayer() {
 
     /**
      * Use this method to override the duration of the current MediaSource object.
-     * 
+     *
      * @throws {@link module:MediaPlayer~PLAYBACK_NOT_INITIALIZED_ERROR PLAYBACK_NOT_INITIALIZED_ERROR} if called before initializePlayback function
      * @param {number} duration
      * @memberof module:MediaPlayer
@@ -1923,6 +1923,44 @@ function MediaPlayer() {
     }
 
     /**
+     *  Reload the manifest that the player is currently using.
+     *
+     *  @memberof module:MediaPlayer
+     *  @param {function} callback - A Callback function provided when retrieving manifests
+     *  @instance
+     */
+    function refreshManifest(callback) {
+        if (!mediaPlayerInitialized) {
+            throw MEDIA_PLAYER_NOT_INITIALIZED_ERROR;
+        }
+
+        if(!isReady()) {
+            callback(null, {
+                error: SOURCE_NOT_ATTACHED_ERROR
+            });
+
+            return;
+        }
+
+        let self = this;
+
+        if (typeof callback === 'function') {
+            const handler = function (e) {
+                if (!e.error) {
+                    callback(e.manifest);
+                } else {
+                    callback(null, e.error);
+                }
+                eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
+            };
+
+            eventBus.on(Events.INTERNAL_MANIFEST_LOADED, handler, self);
+        }
+
+        streamController.refreshManifest();
+    }
+
+    /**
      * Get the current settings object being used on the player.
      * @returns {PlayerSettings} The settings object being used.
      *
@@ -2464,6 +2502,7 @@ function MediaPlayer() {
         extend,
         attachView,
         attachSource,
+        refreshManifest,
         isReady,
         preload,
         play,

--- a/src/streaming/MediaPlayer.js
+++ b/src/streaming/MediaPlayer.js
@@ -1945,7 +1945,8 @@ function MediaPlayer() {
                 eventBus.off(Events.INTERNAL_MANIFEST_LOADED, handler, self);
 
                 if (e.error) {
-                    return callback(null, e.error);
+                    callback(null, e.error);
+                    return;
                 }
 
                 callback(e.manifest);

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1598,6 +1598,10 @@ function StreamController() {
         }
     }
 
+    function refreshManifest() {
+        manifestUpdater.refreshManifest();
+    }
+
     function getStreams() {
         return streams;
     }
@@ -1623,6 +1627,7 @@ function StreamController() {
         getActiveStream,
         getInitialPlayback,
         getAutoPlay,
+        refreshManifest,
         setMediaDuration,
         reset
     };

--- a/test/unit/mocks/StreamControllerMock.js
+++ b/test/unit/mocks/StreamControllerMock.js
@@ -14,6 +14,8 @@ class StreamControllerMock {
         this.streams = streams;
     }
 
+    refreshManifest() {}
+
     getStreams() {
         return this.streams;
     }

--- a/test/unit/streaming.MediaPlayer.js
+++ b/test/unit/streaming.MediaPlayer.js
@@ -1031,31 +1031,11 @@ describe('MediaPlayer', function () {
             it('Method getCurrentLiveLatency should throw an exception', function () {
                 expect(player.getCurrentLiveLatency).to.throw(MEDIA_PLAYER_NOT_INITIALIZED_ERROR);
             });
-
-            it('Method refreshManifest should throw an exception', () => {
-                expect(player.refreshManifest).to.throw(MEDIA_PLAYER_NOT_INITIALIZED_ERROR);
-            });
         });
     });
 
     describe('Stream and Track Management Functions', function () {
         describe('When it is not initialized', function () {
-        });
-
-        describe('When it is not ready', () => {
-            beforeEach(() => {
-                mediaControllerMock.reset();
-            })
-
-            it('triggers refreshManifest callback with an error', () => {
-                player.initialize(videoElementMock, null, false);
-
-                const stub = sinon.spy()
-
-                player.refreshManifest(stub)
-
-                expect(stub.calledWith(null, SOURCE_NOT_ATTACHED_ERROR)).to.be.true;
-            })
         });
 
         describe('When it is initialized', function () {
@@ -1119,6 +1099,22 @@ describe('MediaPlayer', function () {
             it('Method attachSource should throw an exception', function () {
                 expect(player.attachSource).to.throw(MediaPlayer.NOT_INITIALIZED_ERROR_MSG);
             });
+
+            it('Method refreshManifest should throw an exception', () => {
+                expect(player.refreshManifest).to.throw(MEDIA_PLAYER_NOT_INITIALIZED_ERROR);
+            });
+        });
+
+        describe('When it is not ready', () => {
+            it('triggers refreshManifest callback with an error', () => {
+                player.initialize(videoElementMock, null, false);
+
+                const stub = sinon.spy()
+
+                player.refreshManifest(stub)
+
+                expect(stub.calledWith(null, SOURCE_NOT_ATTACHED_ERROR)).to.be.true;
+            })
         });
     });
 
@@ -1197,40 +1193,36 @@ describe('MediaPlayer with context injected', () => {
         });
     });
 
-    describe('Stream and Track Management', () => {
+    describe('Tools Functions', () => {
         describe('When the player is initialised', () => {
+            before(() => {
+                sinon.spy(streamControllerMock, 'refreshManifest');
+            })
+
             beforeEach(() => {
+                streamControllerMock.refreshManifest.resetHistory();
+
                 mediaControllerMock.reset();
-                player.initialize(videoElementMock, specHelper.getDummyUrl(), false);
-                mediaControllerMock.addTrack('track1');
-                mediaControllerMock.addTrack('track2');
-                mediaControllerMock.setTrack('track1');
             });
 
             it('should refresh manifest on the current stream', () => {
-                sinon.spy(streamControllerMock, 'refreshManifest');
-                
+                player.initialize(videoElementMock, specHelper.getDummyUrl(), false);
+
                 const stub = sinon.spy();
 
                 player.refreshManifest(stub);
 
                 expect(streamControllerMock.refreshManifest.calledOnce).to.be.true;
-
-                eventBus.on(Events.INTERNAL_MANIFEST_LOADED, () => {
-                    debugger;
-                    console.log('Fired!')
-                })
+                
                 eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { manifest: { __mocked: true } });
 
                 expect(stub.calledOnce).to.be.true;
                 expect(stub.calledWith(sinon.match({ __mocked: true }))).to.be.true;
-
-                streamControllerMock.refreshManifest.restore();
             });
 
             it('should trigger refreshManifest callback with an error if refresh failed', () => {
-                sinon.spy(streamControllerMock, 'refreshManifest');
-                
+                player.initialize(videoElementMock, specHelper.getDummyUrl(), false);
+
                 const stub = sinon.spy();
 
                 player.refreshManifest(stub);
@@ -1241,8 +1233,6 @@ describe('MediaPlayer with context injected', () => {
 
                 expect(stub.calledOnce).to.be.true;
                 expect(stub.calledWith(null, 'Mocked!')).to.be.true;
-
-                streamControllerMock.refreshManifest.restore();
             });
         })
     })

--- a/test/unit/streaming.MediaPlayer.js
+++ b/test/unit/streaming.MediaPlayer.js
@@ -10,12 +10,11 @@ import MediaPlayerModelMock from './mocks//MediaPlayerModelMock';
 import MediaControllerMock from './mocks/MediaControllerMock';
 import ObjectUtils from './../../src/streaming/utils/ObjectUtils';
 import Constants from '../../src/streaming/constants/Constants';
+import Events from '../../src/core/events/Events';
 import EventBus from '../../src/core/EventBus'
 import Settings from '../../src/core/Settings';
 import ABRRulesCollection from '../../src/streaming/rules/abr/ABRRulesCollection';
 import CustomParametersModel from '../../src/streaming/models/CustomParametersModel';
-import sinon from 'sinon';
-import Events from '../../src/core/events/Events';
 
 const sinon = require('sinon');
 const expect = require('chai').expect;
@@ -47,7 +46,6 @@ describe('MediaPlayer', function () {
     const mediaPlayerModel = new MediaPlayerModelMock();
     const mediaControllerMock = new MediaControllerMock();
     const objectUtils = ObjectUtils(context).getInstance();
-    const eventBus = EventBus(context).getInstance();
     const settings = Settings(context).getInstance();
     const customParametersModel = CustomParametersModel(context).getInstance();
     let player;
@@ -1037,8 +1035,6 @@ describe('MediaPlayer', function () {
             it('Method refreshManifest should throw an exception', () => {
                 expect(player.refreshManifest).to.throw(MEDIA_PLAYER_NOT_INITIALIZED_ERROR);
             });
-
-            it('')
         });
     });
 
@@ -1112,40 +1108,6 @@ describe('MediaPlayer', function () {
                 currentTrack = mediaControllerMock.isCurrentTrack('audio');
                 expect(currentTrack).to.be.true; // jshint ignore:line
             });
-
-            it('should refresh manifest on the current stream', () => {
-                sinon.spy(streamControllerMock, 'refreshManifest');
-                
-                const stub = sinon.spy();
-
-                player.refreshManifest(stub);
-
-                expect(streamControllerMock.refreshManifest.calledOnce).to.be.true;
-
-                eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { manifest: { __mocked: true } });
-
-                expect(stub.calledOnce).to.be.true;
-                expect(stub.calledWith({ __mocked: true })).to.be.true;
-
-                streamControllerMock.refreshManifest.restore();
-            });
-
-            it('should trigger callback if refresh failed', () => {
-                sinon.spy(streamControllerMock, 'refreshManifest');
-                
-                const stub = sinon.spy();
-
-                player.refreshManifest(stub);
-
-                expect(streamControllerMock.refreshManifest.calledOnce).to.be.true;
-
-                eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { error: 'Mocked!' });
-
-                expect(stub.calledOnce).to.be.true;
-                expect(stub.calledWith(null, 'Mocked!')).to.be.true;
-
-                streamControllerMock.refreshManifest.restore();
-            });
         });
     });
 
@@ -1188,3 +1150,100 @@ describe('MediaPlayer', function () {
         });
     });
 });
+
+describe('MediaPlayer with context injected', () => {
+    const specHelper = new SpecHelper();
+    const videoElementMock = new VideoElementMock();
+    const capaMock = new CapabilitiesMock();
+    const streamControllerMock = new StreamControllerMock();
+    const abrControllerMock = new AbrControllerMock();
+    const playbackControllerMock = new PlaybackControllerMock();
+    const mediaPlayerModel = new MediaPlayerModelMock();
+    const mediaControllerMock = new MediaControllerMock();
+
+    let player;
+    let eventBus;
+    let settings;
+
+    beforeEach(function () {
+        // tear down
+        player = null;
+        settings?.reset();
+        settings = null;
+        global.dashjs = {};
+
+        // init
+        const context = {};
+
+        const customParametersModel = CustomParametersModel(context).getInstance();
+        eventBus = EventBus(context).getInstance();
+        settings = Settings(context).getInstance();
+        
+        player = MediaPlayer(context).create();
+
+        // to avoid unwanted log
+        const debug = player.getDebug();
+        expect(debug).to.exist; // jshint ignore:line
+
+        player.setConfig({
+            streamController: streamControllerMock,
+            capabilities: capaMock,
+            playbackController: playbackControllerMock,
+            mediaPlayerModel: mediaPlayerModel,
+            abrController: abrControllerMock,
+            mediaController: mediaControllerMock,
+            settings: settings,
+            customParametersModel
+        });
+    });
+
+    describe('Stream and Track Management', () => {
+        describe('When the player is initialised', () => {
+            beforeEach(() => {
+                mediaControllerMock.reset();
+                player.initialize(videoElementMock, specHelper.getDummyUrl(), false);
+                mediaControllerMock.addTrack('track1');
+                mediaControllerMock.addTrack('track2');
+                mediaControllerMock.setTrack('track1');
+            });
+
+            it('should refresh manifest on the current stream', () => {
+                sinon.spy(streamControllerMock, 'refreshManifest');
+                
+                const stub = sinon.spy();
+
+                player.refreshManifest(stub);
+
+                expect(streamControllerMock.refreshManifest.calledOnce).to.be.true;
+
+                eventBus.on(Events.INTERNAL_MANIFEST_LOADED, () => {
+                    debugger;
+                    console.log('Fired!')
+                })
+                eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { manifest: { __mocked: true } });
+
+                expect(stub.calledOnce).to.be.true;
+                expect(stub.calledWith(sinon.match({ __mocked: true }))).to.be.true;
+
+                streamControllerMock.refreshManifest.restore();
+            });
+
+            it('should trigger refreshManifest callback with an error if refresh failed', () => {
+                sinon.spy(streamControllerMock, 'refreshManifest');
+                
+                const stub = sinon.spy();
+
+                player.refreshManifest(stub);
+
+                expect(streamControllerMock.refreshManifest.calledOnce).to.be.true;
+
+                eventBus.trigger(Events.INTERNAL_MANIFEST_LOADED, { error: 'Mocked!' });
+
+                expect(stub.calledOnce).to.be.true;
+                expect(stub.calledWith(null, 'Mocked!')).to.be.true;
+
+                streamControllerMock.refreshManifest.restore();
+            });
+        })
+    })
+})


### PR DESCRIPTION
## What

Add capability to refresh the manifest

## Why

Our usecase: Ensure it is not possible to search past the end of the stream once a duration is added to a webcast manifest.