### PR TITLE
`pto_posix` anchor support

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1209,7 +1209,6 @@ function StreamController() {
             ptoPosix: posixCalculation({
                 tag: 'pto_posix',
                 presentationTimeFunc: timelineConverter.calcPresentationTimeFromMediaTime,
-                // TODO: Check this is actually right, unsure how to get representation?
                 presentationTimeParam: adapter.getAdaptationForType(0, 'video', getStreams()[0].getStreamInfo()).Representation_asArray[0]
             }),
 

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1242,11 +1242,12 @@ function StreamController() {
         }
 
         const posix = findTag(targetString, 'posix:');
-        const posixTime = timelineConverter.calcPresentationTimeFromWallTime(new Date(posix * 1000), period)
+        // TODO: Causing 5 Test Failures, due to mangled logic
+        // See https://github.com/bbc/dash.js/blob/88f92cbe280cef47f24dd917198af2145c84860a/src/streaming/controllers/StreamController.js#L1183
+        const posixTime = (isDynamic && !isNaN(posix)) ? timelineConverter.calcPresentationTimeFromWallTime(new Date(posix * 1000), period) : parseFloat(targetString) + referenceTime;
         const tagTime = ptoPosixTime || posixTime || NaN;
-        const startTime = (isDynamic && !isNaN(tagTime)) ? tagTime : parseFloat(targetString) + referenceTime;
 
-        return startTime;
+        return tagTime;
     }
 
     /**

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1087,8 +1087,12 @@ function StreamController() {
             // If start time in URI, take min value between live edge time and time from URI (capped by DVR window range)
             const dvrWindow = dvrInfo ? dvrInfo.range : null;
             if (dvrWindow) {
+                const startTimeProvided = !isNaN(providedStartTime)
+                    || providedStartTime.toString().indexOf('posix:') !== -1
+                    || providedStartTime.toString().indexOf('pto_posix:') !== -1;
+
                 // If start time was provided by the application as part of the call to initialize() or attachSource() use this value
-                if (!isNaN(providedStartTime) || providedStartTime.toString().indexOf('posix:') !== -1) {
+                if (startTimeProvided) {
                     logger.info(`Start time provided by the app: ${providedStartTime}`);
                     const providedStartTimeAsPresentationTime = _getStartTimeFromProvidedData(true, providedStartTime)
                     if (!isNaN(providedStartTimeAsPresentationTime)) {

--- a/test/unit/helpers/ObjectsHelper.js
+++ b/test/unit/helpers/ObjectsHelper.js
@@ -60,6 +60,7 @@ class ObjectsHelper {
                 return { start, end };
             },
             calcMediaTimeFromPresentationTime: () => undefined,
+            calcPresentationTimeFromMediaTime: () => undefined,
             calcSegmentAvailabilityWindowForRepresentation: () => {
                 return { start: start, end: end };
             },


### PR DESCRIPTION
Despite not being used elsewhere in the codebase, Nullish Coalescing Operators are supported by the version of [`@babel/preset-env`](https://github.com/babel/babel/blob/e2abc19c4c8d4180f631fcf24f714c048aaa58a4/packages/babel-preset-env/src/available-plugins.js#L10) used in Dash: [package.json](https://github.com/bbc/dash.js/blob/88f92cbe280cef47f24dd917198af2145c84860a/package.json#L25). This allows filtering of `null` results which wouldn't be caught by `isNaN` alone and also technically fixes a bug in the SMP implementation where `posix:0` or `pto_posix:0` anchors would cause issues due to `0` being falsy and the check being `||` to filter `NaN`, this is Unit Tested in Dash.js now. 

On this note, I noticed that the (5 year old) pre Babel Namespace version, `babel-preset-env` is still a `devDependency`, should remember to make an upstream contribution for this.

# TODO
- [ ] Verify Method of getting representation for `timelineConverter.calcPresentationTimeFromMediaTime`
- [ ] Unit Tests for `pto_posix`
- [x] `babel-preset-env` 

