### PR TITLE
Emit waiting and playing events when a stream has stalled

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -107,6 +107,7 @@ import Events from './events/Events';
  *                stallThreshold: 0.3,
  *                useAppendWindow: true,
  *                setStallState: true,
+ *                emitSyntheticStallEvents: true,
  *                avoidCurrentTimeRangePruning: false,
  *                useChangeTypeForTrackSwitch: true
  *            },
@@ -325,7 +326,9 @@ import Events from './events/Events';
  * @property {boolean} [useAppendWindow=true]
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=true]
- * Specifies if we fire manual waiting events once the stall threshold is reached
+ * Specifies if we record stalled streams once the stall threshold is reached
+ * @property {boolean} [emitSyntheticStallEvents=true]
+ * Specified if we fire manual stall events once the stall threshold is reached
  * @property {boolean} [avoidCurrentTimeRangePruning=false]
  * Avoids pruning of the buffered range that contains the current playback time.
  *
@@ -878,6 +881,7 @@ function Settings() {
                 stallThreshold: 0.3,
                 useAppendWindow: true,
                 setStallState: true,
+                emitSyntheticStallEvents: true,
                 avoidCurrentTimeRangePruning: false,
                 useChangeTypeForTrackSwitch: true
             },

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -34,6 +34,7 @@ import EventBus from '../../core/EventBus';
 import Events from '../../core/events/Events';
 import Debug from '../../core/Debug';
 import Constants from '../constants/Constants';
+import Settings from '../../core/Settings';
 
 
 const READY_STATES_TO_EVENT_NAMES = new Map([
@@ -58,6 +59,7 @@ function VideoModel() {
     const context = this.context;
     const eventBus = EventBus(context).getInstance();
     const stalledStreams = [];
+    const settings = Settings(context).getInstance();
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -221,6 +223,14 @@ function VideoModel() {
         }
 
         stalledStreams.push(type);
+        if (settings.get().streaming.buffer.emitSyntheticStallEvents && element && stalledStreams.length === 1) {
+            // Halt playback until nothing is stalled.
+            const event = document.createEvent('Event');
+            event.initEvent('waiting', true, false);
+            previousPlaybackRate = element.playbackRate;
+            setPlaybackRate(0);
+            element.dispatchEvent(event);
+        }
     }
 
     function removeStalledStream(type) {
@@ -233,6 +243,15 @@ function VideoModel() {
             stalledStreams.splice(index, 1);
         }
 
+        // If nothing is stalled resume playback.
+        if (settings.get().streaming.buffer.emitSyntheticStallEvents && element && isStalled() === false && element.playbackRate === 0) {
+            setPlaybackRate(previousPlaybackRate || 1);
+            if (!element.paused) {
+                const event = document.createEvent('Event');
+                event.initEvent('playing', true, false);
+                element.dispatchEvent(event);
+            }
+        }
     }
 
     function stallStream(type, isStalled) {


### PR DESCRIPTION
### What
Some devices do not emit `waiting` or `playing` events from the media element when a stream has stalled. This often corresponds to the `readyState` also being in an odd state (e.g 4, when there is no buffer to play through) so can not be relied upon instead.

This 'manual stall event' behaviour was in mainline dash.js prior to version 4.

### How
- add a new setting `emitSyntheticStallEvents`.
- dispatch a `waiting` or `playing` event on stream stall and resume
- set playback rate to 0 on stall and back to initial value on resume