### PR TITLE
fix: remove prepack step

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
         "test": "karma start karma.unit.conf.js",
         "test-browserunit": "karma start build/karma.conf.js",
         "test-functional": "node test/functional/runTests.js --selenium=remote --app=remote",
-        "prepare": "node githook.js",
-        "prepack": "npm run build"
+        "prepare": "node githook.js"
     },
     "devDependencies": {
         "@babel/core": "^7.13.8",


### PR DESCRIPTION
# What

Remove the prepack step from the package.json

# Why

Unused. We pack the Dash.js source ourselves. Causing an issue in the TV client release pipeline. Slows down installs.