### PR TITLE
BADGERS fix: don't emit synthetic stall if media element reports playback is not ready

### DIFF
--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -226,7 +226,8 @@ function VideoModel() {
         }
 
         stalledStreams.push(type);
-        if (settings.get().streaming.buffer.emitSyntheticStallEvents && element && stalledStreams.length === 1) {
+        if (settings.get().streaming.buffer.emitSyntheticStallEvents && element && stalledStreams.length === 1 && element.readyState >= Constants.VIDEO_ELEMENT_READY_STATES.HAVE_FUTURE_DATA) {
+            logger.debug(`emitting synthetic waiting event and halting playback with playback rate 0`);
             // Halt playback until nothing is stalled.
             const event = document.createEvent('Event');
             event.initEvent('waiting', true, false);
@@ -247,7 +248,8 @@ function VideoModel() {
         }
 
         // If nothing is stalled resume playback.
-        if (settings.get().streaming.buffer.emitSyntheticStallEvents && element && isStalled() === false && element.playbackRate === 0) {
+        if (settings.get().streaming.buffer.emitSyntheticStallEvents && element && isStalled() === false && element.playbackRate === 0 && element.readyState >= Constants.VIDEO_ELEMENT_READY_STATES.HAVE_FUTURE_DATA) {
+            logger.debug(`emitting synthetic playing event (if not paused) and resuming playback with playback rate: ${previousPlaybackRate || 1}`);
             setPlaybackRate(previousPlaybackRate || 1);
             if (!element.paused) {
                 const event = document.createEvent('Event');


### PR DESCRIPTION
## What?

Title.

### Why?

There are TV devices that break if playback rate is set when the device's media element reports a ready state less than 2.

## How?

- Check ready state reported by media element. Trust the media element to emit `waiting` events as expected if it reports a ready state less than 3 when at least one source buffer is out of data.
- Add log messages.