### PR TITLE
Add option to ignore ready state check for synthetic stalls

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -107,11 +107,15 @@ import Events from './events/Events';
  *                stallThreshold: 0.3,
  *                useAppendWindow: true,
  *                setStallState: true,
- *                emitSyntheticStallEvents: false,
  *                avoidCurrentTimeRangePruning: false,
  *                useChangeTypeForTrackSwitch: true,
  *                mediaSourceDurationInfinity: true,
- *                resetSourceBuffersForTrackSwitch: false
+ *                resetSourceBuffersForTrackSwitch: false,
+ *                syntheticStallEvents: {
+ *                  enabled: false,
+ *                  ignoreReadyState: false
+ *                } 
+ * 
  *            },
  *            gaps: {
  *                jumpGaps: true,
@@ -337,7 +341,7 @@ import Events from './events/Events';
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=true]
  * Specifies if we record stalled streams once the stall threshold is reached
- * @property {boolean} [emitSyntheticStallEvents=false]
+ * @property {module:Settings~SyntheticStallSettings} [syntheticStallEvents]
  * Specified if we fire manual stall events once the stall threshold is reached
  * @property {boolean} [avoidCurrentTimeRangePruning=false]
  * Avoids pruning of the buffered range that contains the current playback time.
@@ -360,6 +364,17 @@ import Events from './events/Events';
  * Configuration for audio media type of tracks.
  * @property {number|boolean|string} [video]
  * Configuration for video media type of tracks.
+ */
+
+/**
+ * @typedef {Object} module:Settings~SyntheticStallSettings
+ * @property {boolean} [enabled]
+ * Fire manual stall events once the stall threshold is reached
+ * @property {boolean} [ignoreReadyState]
+ * Ignore the media element's ready state when entering and exiting a stall
+ * Enable this when either of these scenarios still occur with synthetic stalls enabled:
+ * - If the buffer is empty, but playback is not stalled.
+ * - If playback resumes, but a playing event isn't reported.
  */
 
 /**
@@ -920,11 +935,14 @@ function Settings() {
                 stallThreshold: 0.3,
                 useAppendWindow: true,
                 setStallState: true,
-                emitSyntheticStallEvents: false,
                 avoidCurrentTimeRangePruning: false,
                 useChangeTypeForTrackSwitch: true,
                 mediaSourceDurationInfinity: true,
-                resetSourceBuffersForTrackSwitch: false
+                resetSourceBuffersForTrackSwitch: false,
+                syntheticStallEvents: {
+                    enabled: false,
+                    ignoreReadyState: false
+                }
             },
             gaps: {
                 jumpGaps: true,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -107,7 +107,7 @@ import Events from './events/Events';
  *                stallThreshold: 0.3,
  *                useAppendWindow: true,
  *                setStallState: true,
- *                emitSyntheticStallEvents: true,
+ *                emitSyntheticStallEvents: false,
  *                avoidCurrentTimeRangePruning: false,
  *                useChangeTypeForTrackSwitch: true,
  *                mediaSourceDurationInfinity: true,
@@ -337,7 +337,7 @@ import Events from './events/Events';
  * Specifies if the appendWindow attributes of the MSE SourceBuffers should be set according to content duration from manifest.
  * @property {boolean} [setStallState=true]
  * Specifies if we record stalled streams once the stall threshold is reached
- * @property {boolean} [emitSyntheticStallEvents=true]
+ * @property {boolean} [emitSyntheticStallEvents=false]
  * Specified if we fire manual stall events once the stall threshold is reached
  * @property {boolean} [avoidCurrentTimeRangePruning=false]
  * Avoids pruning of the buffered range that contains the current playback time.
@@ -920,7 +920,7 @@ function Settings() {
                 stallThreshold: 0.3,
                 useAppendWindow: true,
                 setStallState: true,
-                emitSyntheticStallEvents: true,
+                emitSyntheticStallEvents: false,
                 avoidCurrentTimeRangePruning: false,
                 useChangeTypeForTrackSwitch: true,
                 mediaSourceDurationInfinity: true,

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -86,7 +86,7 @@ function VideoModel() {
             return;
         }
 
-        if (value === 0 || ignoreReadyState || element.readyState > Constants.VIDEO_ELEMENT_READY_STATES.HAVE_CURRENT_DATA) {
+        if (value === 0 || ignoreReadyState) {
             element.playbackRate = value;
             return;
         }

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -238,13 +238,13 @@ function VideoModel() {
     }
 
     function addStalledStream(type) {
-
         if (type === null || !element || element.seeking || stalledStreams.indexOf(type) !== -1) {
             return;
         }
 
         stalledStreams.push(type);
-        if (settings.get().streaming.buffer.emitSyntheticStallEvents && element && stalledStreams.length === 1 && element.readyState >= Constants.VIDEO_ELEMENT_READY_STATES.HAVE_FUTURE_DATA) {
+
+        if (settings.get().streaming.buffer.emitSyntheticStallEvents && element && stalledStreams.length === 1) {
             logger.debug(`emitting synthetic waiting event and halting playback with playback rate 0`);
             // Halt playback until nothing is stalled.
             const event = document.createEvent('Event');

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -481,15 +481,18 @@ function VideoModel() {
     }
 
     function waitForReadyState(targetReadyState, callback) {
-        if (targetReadyState === Constants.VIDEO_ELEMENT_READY_STATES.HAVE_NOTHING ||
-            getReadyState() >= targetReadyState) {
+        if (
+            targetReadyState === Constants.VIDEO_ELEMENT_READY_STATES.HAVE_NOTHING ||
+            getReadyState() >= targetReadyState
+        ) {
             callback();
             return null;
-        } else {
-            // wait for the appropriate callback before checking again
-            const event = READY_STATES_TO_EVENT_NAMES[targetReadyState];
-            _listenOnce(event, callback);
         }
+
+        // wait for the appropriate callback before checking again
+        const event = READY_STATES_TO_EVENT_NAMES[targetReadyState];
+
+        return _listenOnce(event, callback);
     }
 
     function _listenOnce(event, callback) {
@@ -499,6 +502,7 @@ function VideoModel() {
             // Call the original listener.
             callback(event);
         };
+
         addEventListener(event, func);
 
         return { func, event }

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -86,7 +86,7 @@ function VideoModel() {
             return;
         }
 
-        if (value === 0 || ignoreReadyState) {
+        if (ignoreReadyState) {
             element.playbackRate = value;
             return;
         }
@@ -251,11 +251,14 @@ function VideoModel() {
             (settings.get().streaming.buffer.syntheticStallEvents.ignoreReadyState || getReadyState() >= Constants.VIDEO_ELEMENT_READY_STATES.HAVE_FUTURE_DATA)
         ) {
             logger.debug(`emitting synthetic waiting event and halting playback with playback rate 0`);
+
+            previousPlaybackRate = element.playbackRate;
+
+            setPlaybackRate(0, true);
+
             // Halt playback until nothing is stalled.
             const event = document.createEvent('Event');
             event.initEvent('waiting', true, false);
-            previousPlaybackRate = element.playbackRate;
-            setPlaybackRate(0);
             element.dispatchEvent(event);
         }
     }
@@ -275,7 +278,7 @@ function VideoModel() {
             const resume = () => { 
                 logger.debug(`emitting synthetic playing event (if not paused) and resuming playback with playback rate: ${previousPlaybackRate || 1}`);
 
-                setPlaybackRate(previousPlaybackRate || 1, settings.get().streaming.buffer.syntheticStalls.ignoreReadyState);
+                setPlaybackRate(previousPlaybackRate || 1, settings.get().streaming.buffer.syntheticStallEvents.ignoreReadyState);
 
                 if (!element.paused) {
                     const event = document.createEvent('Event');
@@ -284,7 +287,7 @@ function VideoModel() {
                 }
             }
 
-            if (settings.get().streaming.buffer.syntheticStalls.ignoreReadyState) {
+            if (settings.get().streaming.buffer.syntheticStallEvents.ignoreReadyState) {
                 resume()
             } else {
                 if (resumeReadyStateFunction && resumeReadyStateFunction.func && resumeReadyStateFunction.event) {

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -274,7 +274,9 @@ function VideoModel() {
         if (settings.get().streaming.buffer.syntheticStallEvents.enabled && element && !isStalled() && element.playbackRate === 0) {
             const resume = () => { 
                 logger.debug(`emitting synthetic playing event (if not paused) and resuming playback with playback rate: ${previousPlaybackRate || 1}`);
-                setPlaybackRate(previousPlaybackRate || 1);
+
+                setPlaybackRate(previousPlaybackRate || 1, settings.get().streaming.buffer.syntheticStalls.ignoreReadyState);
+
                 if (!element.paused) {
                     const event = document.createEvent('Event');
                     event.initEvent('playing', true, false);


### PR DESCRIPTION
## What

Title.

## Why

~~We know the list of devices that need synthetic stalls, so the check isn't needed~~

We cannot trust all devices that report a `stalled` state from ready state to do stalls correctly. This option enables us to ignore that on those devices.