### PR TITLE
Add seekWithoutReadyStateCheck override property

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -773,6 +773,8 @@ import Events from './events/Events';
  * Overwrite the manifest segments base information timescale attributes with the timescale set in initialization segments
  * @property {boolean} [enableManifestTimescaleMismatchFix=false]
  * Defines the delay in milliseconds between two consecutive checks for events to be fired.
+ * @property {boolean} [seekWithoutReadyStateCheck=false]
+ * This allows a seek by setting currentTime regardless of the loadedmetadata event being emitted
  * @property {boolean} [parseInbandPrft=false]
  * Set to true if dash.js should parse inband prft boxes (ProducerReferenceTime) and trigger events.
  * @property {module:Settings~Metrics} metrics Metric settings
@@ -898,6 +900,7 @@ function Settings() {
             enableManifestDurationMismatchFix: true,
             parseInbandPrft: false,
             enableManifestTimescaleMismatchFix: false,
+            seekWithoutReadyStateCheck: false,
             capabilities: {
                 filterUnsupportedEssentialProperties: true,
                 useMediaCapabilitiesApi: false

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -105,13 +105,13 @@ function VideoModel() {
             }
             _currentTime = currentTime;
 
-            let currentTimeReadyState = Constants.VIDEO_ELEMENT_READY_STATES.HAVE_METADATA;
+            let elementReadyStateEvent = Constants.VIDEO_ELEMENT_READY_STATES.HAVE_METADATA;
 
             if (settings.get().streaming.seekWithoutReadyStateCheck) {
-                currentTimeReadyState = Constants.VIDEO_ELEMENT_READY_STATES.HAVE_NOTHING;
+                elementReadyStateEvent = Constants.VIDEO_ELEMENT_READY_STATES.HAVE_NOTHING;
             }
 
-            setCurrentTimeReadyStateFunction = waitForReadyState(currentTimeReadyState, () => {
+            setCurrentTimeReadyStateFunction = waitForReadyState(elementReadyStateEvent, () => {
                 if (!element) {
                     return;
                 }

--- a/src/streaming/models/VideoModel.js
+++ b/src/streaming/models/VideoModel.js
@@ -104,7 +104,14 @@ function VideoModel() {
                 removeEventListener(setCurrentTimeReadyStateFunction.event, setCurrentTimeReadyStateFunction.func);
             }
             _currentTime = currentTime;
-            setCurrentTimeReadyStateFunction = waitForReadyState(Constants.VIDEO_ELEMENT_READY_STATES.HAVE_METADATA, () => {
+
+            let currentTimeReadyState = Constants.VIDEO_ELEMENT_READY_STATES.HAVE_METADATA;
+
+            if (settings.get().streaming.seekWithoutReadyStateCheck) {
+                currentTimeReadyState = Constants.VIDEO_ELEMENT_READY_STATES.HAVE_NOTHING;
+            }
+
+            setCurrentTimeReadyStateFunction = waitForReadyState(currentTimeReadyState, () => {
                 if (!element) {
                     return;
                 }


### PR DESCRIPTION
## What
Since dash.js v4, seeking within a stream relies upon a media element event (`loadedmetadata`) being emitted that corresponds to the `HAVE_METADATA` readyState.

Some browser implementations do not always emit this event when expected. This can result in stalled playback sessions.

## How
- Bypass the check for the `loadedmetadata` event by looking for `HAVE_NOTHING`. This synchronously calls the callback vs waiting for an event.
- Implement feature flag called `seekWithoutReadyStateCheck` in the settings that defaults to `false`.