### PR TITLE
Make PLAYBACK_ENDED event behaviour configurable in PlaybackController

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -775,6 +775,8 @@ import Events from './events/Events';
  * Defines the delay in milliseconds between two consecutive checks for events to be fired.
  * @property {boolean} [seekWithoutReadyStateCheck=false]
  * This allows a seek by setting currentTime regardless of the loadedmetadata event being emitted
+ * @property {boolean} [enableDashPlaybackEnded = false]
+ * This enables the synthetic ended behaviour in PlaybackController that seeks and pauses the media element
  * @property {boolean} [parseInbandPrft=false]
  * Set to true if dash.js should parse inband prft boxes (ProducerReferenceTime) and trigger events.
  * @property {module:Settings~Metrics} metrics Metric settings
@@ -901,6 +903,7 @@ function Settings() {
             parseInbandPrft: false,
             enableManifestTimescaleMismatchFix: false,
             seekWithoutReadyStateCheck: false,
+            enableDashPlaybackEnded: false,
             capabilities: {
                 filterUnsupportedEssentialProperties: true,
                 useMediaCapabilitiesApi: false

--- a/src/streaming/controllers/PlaybackController.js
+++ b/src/streaming/controllers/PlaybackController.js
@@ -699,7 +699,7 @@ function PlaybackController() {
 
     // Handle DASH PLAYBACK_ENDED event
     function _onPlaybackEnded(e) {
-        if (wallclockTimeIntervalId && e.isLast) {
+        if (settings.get().streaming.enableDashPlaybackEnded && wallclockTimeIntervalId && e.isLast) {
             // PLAYBACK_ENDED was triggered elsewhere, react.
             logger.info('onPlaybackEnded -- PLAYBACK_ENDED but native video element didn\'t fire ended');
             const seekTime = e.seekTime ? e.seekTime : getStreamEndTime();


### PR DESCRIPTION
## What

Some browsers do not fire their native `ended` event from the media element in a timely manner. The interval to fire the dash.js internal `PLAYBACK_ENDED` event can fire before native `ended` is emitted and instead cause a seek and a pause. This prevents the native ended event from then firing and the player remains in a paused state.

We've added a configurable property to turn the internal `PLAYBACK_ENDED` behaviour off.

## How
- Implement a settings property `enableDashPlaybackEnded ` to control the behaviour. This defaults to `false`.