### PR TITLE
Fix: Buffer Level Reporting

### DIFF
--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -719,8 +719,10 @@ function BufferController(config) {
     }
 
     function _onPlaybackProgression() {
-        if (!replacingBuffer && (type === Constants.TEXT && textController.isTextEnabled())) {
-            _updateBufferLevel();
+        if (!replacingBuffer) {
+            if(type !== Constants.TEXT || (type === Constants.TEXT && textController.isTextEnabled())){
+                _updateBufferLevel();
+            }
         }
     }
 

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -718,9 +718,8 @@ function BufferController(config) {
         return null;
     }
 
-
     function _onPlaybackProgression() {
-        if (!replacingBuffer || (type === Constants.TEXT && textController.isTextEnabled())) {
+        if (!replacingBuffer && (type === Constants.TEXT && textController.isTextEnabled())) {
             _updateBufferLevel();
         }
     }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -719,8 +719,9 @@ function BufferController(config) {
     }
 
     function _onPlaybackProgression() {
+        console.log(`Replacing Buffer: ${replacingBuffer}, Track: ${type}, Enabled: ${textController.isTextEnabled()}`)
         if (!replacingBuffer) {
-            if(type !== Constants.TEXT || (type === Constants.TEXT && textController.isTextEnabled())){
+            if(type !== Constants.TEXT || textController.isTextEnabled()){
                 _updateBufferLevel();
             }
         }

--- a/src/streaming/controllers/BufferController.js
+++ b/src/streaming/controllers/BufferController.js
@@ -719,7 +719,6 @@ function BufferController(config) {
     }
 
     function _onPlaybackProgression() {
-        console.log(`Replacing Buffer: ${replacingBuffer}, Track: ${type}, Enabled: ${textController.isTextEnabled()}`)
         if (!replacingBuffer) {
             if(type !== Constants.TEXT || textController.isTextEnabled()){
                 _updateBufferLevel();

--- a/src/streaming/metrics/metrics/handlers/BufferLevelHandler.js
+++ b/src/streaming/metrics/metrics/handlers/BufferLevelHandler.js
@@ -94,7 +94,12 @@ function BufferLevelHandler(config) {
 
     function handleNewMetric(metric, vo, type) {
         if (metric === metricsConstants.BUFFER_LEVEL) {
-            storedVOs[type] = vo;
+            if(vo.level < 0){
+                delete storedVOs[type]
+            }
+            else{
+                storedVOs[type] = vo;
+            }
         }
     }
 

--- a/src/streaming/text/TextController.js
+++ b/src/streaming/text/TextController.js
@@ -278,6 +278,10 @@ function TextController(config) {
         // Fragmented text tracks need the additional step of calling TextController.setTextTrack();
         allTracksAreDisabled = idx === -1;
 
+        if(allTracksAreDisabled){
+            eventBus.trigger(Events.BUFFER_LEVEL_UPDATED, { mediaType: Constants.TEXT, bufferLevel: -1 }, { streamId, mediaType: Constants.TEXT});
+        }
+
         if (allTracksAreDisabled && mediaController) {
             mediaController.saveTextSettingsDisabled();
         }


### PR DESCRIPTION
Fixes an issue in Dash.js where the buffer level of text tacks is continually reported even when the track is disabled.

The buffer level for DVB metrics is reported as a minimum of all media tracks. This results in the DVB Buffer Level being reported as 0 when subtitles are not in use.

This PR prevents text track buffer level being reporting when it's disabled and provides a method to reset and already stored text track buffer level measurements.