### PR TITLE
Video frames not advancing updates

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -111,7 +111,7 @@ import Events from './events/Events';
  *                setStallState: true,
  *                videoFramesNotAdvancing: {
  *                   enabled: false
- *                   thresholdInSeconds: 2,
+ *                   thresholdInSeconds: 5,
  *                },
  *                avoidCurrentTimeRangePruning: false,
  *                useChangeTypeForTrackSwitch: true,
@@ -359,7 +359,7 @@ import Events from './events/Events';
  * @property {module:Settings~SyntheticStallSettings} [syntheticStallEvents]
  * Specified if we fire manual stall events once the stall threshold is reached
  * 
- * @property {number} [videoFramesNotAdvancing={enabled:false,thresholdInSeconds:2}]
+ * @property {number} [videoFramesNotAdvancing={enabled:false,thresholdInSeconds:5}]
  * Controls a mechanism for handling situations where the player is playing but stops advancing its total frame count to handle https://issues.chromium.org/issues/41243192. 
  * 
  * The 'enabled' property signifies whether we attempt to handle the bug should it occur by seeking to the current time.
@@ -1001,7 +1001,7 @@ function Settings() {
                 setStallState: true,
                 videoFramesNotAdvancing: {
                     enabled: false,
-                    thresholdInSeconds: 2
+                    thresholdInSeconds: 5
                 },
                 avoidCurrentTimeRangePruning: false,
                 useChangeTypeForTrackSwitch: true,

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -814,8 +814,7 @@ function StreamController() {
             && playbackQuality.totalVideoFrames > 0 // Handles devices (some TVs), where Video Quality API, totalVideoFrames always returns 0.
             && playbackQuality.totalVideoFrames < 2147483647 //Handles devices (some WebKit TVs), where Video Quality API, totalVideoFrames can return the max value of a 32 bit signed integer becuase the implementation uses totalVideoFrames = mediaTime * framerate.
             && playbackQuality.totalVideoFrames !== playbackQuality.droppedVideoFrames // Handles devices (some TVs), where Video Quality API, totalVideoFrames always equals the number of dropped frames.
-            && playbackQuality.totalVideoFrames >= totalVideoFramesAtLastPlaybackProgress // Handles devices (some WebKit TVs) where total video frames is reset if the decoder is reinitialised.
-            && playbackQuality.totalVideoFrames === totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong.
+            && playbackQuality.totalVideoFrames === totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong. On some some WebKit TVs the total video frames is reset if the decoder is reinitialised.
 
         if(isVideoFramesNotAdvancing){
             if((timeAtLastPlaybackProgress + settings.get().streaming.buffer.videoFramesNotAdvancing.thresholdInSeconds < event.time) && !videoFramesNotAdvancingTriggered){

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -811,10 +811,10 @@ function StreamController() {
             && !videoModel.isPaused()
             && !videoModel.isStalled()
             && videoModel.getReadyState() >= Constants.VIDEO_ELEMENT_READY_STATES.HAVE_ENOUGH_DATA
-            && playbackQuality.totalVideoFrames > 0 // Handles devices (some tvs), where Video Quality API, totalVideoFrames always returns 0
-            && playbackQuality.totalVideoFrames < 2147483647 //Handles devices (some tvs), where Video Quality API, totalVideoFrames always returns max value of a 32 bit signed integer
-            && playbackQuality.totalVideoFrames !== playbackQuality.droppedVideoFrames // Handles devices (some tvs), where Video Quality API, totalVideoFrames always equals the number of dropped frames
-            && playbackQuality.totalVideoFrames <= totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong
+            && playbackQuality.totalVideoFrames > 0 // Handles devices (some TVs), where Video Quality API, totalVideoFrames always returns 0.
+            && playbackQuality.totalVideoFrames < 2147483647 //Handles devices (some WebKit TVs), where Video Quality API, totalVideoFrames can return the max value of a 32 bit signed integer becuase the implementation uses totalVideoFrames = mediaTime * framerate.
+            && playbackQuality.totalVideoFrames !== playbackQuality.droppedVideoFrames // Handles devices (some TVs), where Video Quality API, totalVideoFrames always equals the number of dropped frames.
+            && playbackQuality.totalVideoFrames !== totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong. On some WebKit TVs this value is reset if the decoder is reinitialised.
     
         if(isVideoFramesNotAdvancing){
             if((timeAtLastPlaybackProgress + settings.get().streaming.buffer.videoFramesNotAdvancing.thresholdInSeconds < event.time) && !videoFramesNotAdvancingTriggered){

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -815,7 +815,8 @@ function StreamController() {
             && playbackQuality.totalVideoFrames < 2147483647 //Handles devices (some WebKit TVs), where Video Quality API, totalVideoFrames can return the max value of a 32 bit signed integer becuase the implementation uses totalVideoFrames = mediaTime * framerate.
             && playbackQuality.totalVideoFrames !== playbackQuality.droppedVideoFrames // Handles devices (some TVs), where Video Quality API, totalVideoFrames always equals the number of dropped frames.
             && playbackQuality.totalVideoFrames >= totalVideoFramesAtLastPlaybackProgress // Handles devices (some WebKit TVs) where total video frames is reset if the decoder is reinitialised.
-            && playbackQuality.totalVideoFrames !== totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong.
+            && playbackQuality.totalVideoFrames === totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong.
+
         if(isVideoFramesNotAdvancing){
             if((timeAtLastPlaybackProgress + settings.get().streaming.buffer.videoFramesNotAdvancing.thresholdInSeconds < event.time) && !videoFramesNotAdvancingTriggered){
                 eventBus.trigger(Events.PLAYBACK_FROZEN,{cause:'Frames have stopped advancing, Chromium bug #41243192', totalVideoFrames: playbackQuality.totalVideoFrames, time: event.time });

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -814,8 +814,8 @@ function StreamController() {
             && playbackQuality.totalVideoFrames > 0 // Handles devices (some TVs), where Video Quality API, totalVideoFrames always returns 0.
             && playbackQuality.totalVideoFrames < 2147483647 //Handles devices (some WebKit TVs), where Video Quality API, totalVideoFrames can return the max value of a 32 bit signed integer becuase the implementation uses totalVideoFrames = mediaTime * framerate.
             && playbackQuality.totalVideoFrames !== playbackQuality.droppedVideoFrames // Handles devices (some TVs), where Video Quality API, totalVideoFrames always equals the number of dropped frames.
-            && playbackQuality.totalVideoFrames !== totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong. On some WebKit TVs this value is reset if the decoder is reinitialised.
-    
+            && playbackQuality.totalVideoFrames >= totalVideoFramesAtLastPlaybackProgress // Handles devices (some WebKit TVs) where total video frames is reset if the decoder is reinitialised.
+            && playbackQuality.totalVideoFrames !== totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong.
         if(isVideoFramesNotAdvancing){
             if((timeAtLastPlaybackProgress + settings.get().streaming.buffer.videoFramesNotAdvancing.thresholdInSeconds < event.time) && !videoFramesNotAdvancingTriggered){
                 eventBus.trigger(Events.PLAYBACK_FROZEN,{cause:'Frames have stopped advancing, Chromium bug #41243192', totalVideoFrames: playbackQuality.totalVideoFrames, time: event.time });

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -812,6 +812,7 @@ function StreamController() {
             && !videoModel.isStalled()
             && videoModel.getReadyState() >= Constants.VIDEO_ELEMENT_READY_STATES.HAVE_ENOUGH_DATA
             && playbackQuality.totalVideoFrames > 0 // Handles devices (some tvs), where Video Quality API, totalVideoFrames always returns 0
+            && playbackQuality.totalVideoFrames < 2147483647 //Handles devices (some tvs), where Video Quality API, totalVideoFrames always returns max value of a 32 bit signed integer
             && playbackQuality.totalVideoFrames !== playbackQuality.droppedVideoFrames // Handles devices (some tvs), where Video Quality API, totalVideoFrames always equals the number of dropped frames
             && playbackQuality.totalVideoFrames <= totalVideoFramesAtLastPlaybackProgress // Total frames should advance with time progression, if not something is wrong
     


### PR DESCRIPTION
Update the` videoFramesNotAdvancing` implementation to handle additional invalid or inaccurate values being reported by the Video Quality API.

Deals with 3 observed cases:

- Increases the default `thresholdInSeconds` to 5. As many WebKit-based TV environment only appear to provide an update to this value every ~2-seconds
- Handle cases where some devices always report the maximum value of 32-bit signed integer as their `totalVideoFrames` value on the Video Quality API when playing a live stream. Caused by some implementations using `totalVideoFrames = mediaTime * frameRate`
- Finally, only trigger when frames are explicitly not changing, i.e `previousFrames !== currentFrames`. Some devices appear to reset `totalVideoFrames` to `0` if the decoder is reinitialised.
