### PR TITLE
Video Frames Not Advancing, check for start and end of video

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -818,6 +818,7 @@ function StreamController() {
             && event.time > settings.get().streaming.buffer.videoFramesNotAdvancing.thresholdInSeconds // We should be at least one threshold into the video before triggering
             && !videoModel.isPaused()
             && !videoModel.isStalled()
+            && !videoModel.isSeeking()
             && videoModel.getReadyState() >= Constants.VIDEO_ELEMENT_READY_STATES.HAVE_ENOUGH_DATA
             && playbackQuality.totalVideoFrames > 0 // Handles devices (some TVs), where Video Quality API, totalVideoFrames always returns 0.
             && playbackQuality.totalVideoFrames < 2147483647 //Handles devices (some WebKit TVs), where Video Quality API, totalVideoFrames can return the max value of a 32 bit signed integer becuase the implementation uses totalVideoFrames = mediaTime * framerate.

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -805,9 +805,17 @@ function StreamController() {
 
         const playbackQuality = videoModel.getPlaybackQuality();
 
+        if(videoModel.isSeeking()){
+            totalVideoFramesAtLastPlaybackProgress = 0
+        }
+
+        const isEnded = event.timeToEnd ? event.timeToEnd >= 0 : false;
+
         const isVideoFramesNotAdvancing = playbackQuality &&
             typeof playbackQuality.totalVideoFrames === 'number'
+            && !isEnded
             && timeAtLastPlaybackProgress !== 0
+            && event.time > settings.get().streaming.buffer.videoFramesNotAdvancing.thresholdInSeconds // We should be at least one threshold into the video before triggering
             && !videoModel.isPaused()
             && !videoModel.isStalled()
             && videoModel.getReadyState() >= Constants.VIDEO_ELEMENT_READY_STATES.HAVE_ENOUGH_DATA
@@ -818,7 +826,13 @@ function StreamController() {
 
         if(isVideoFramesNotAdvancing){
             if((timeAtLastPlaybackProgress + settings.get().streaming.buffer.videoFramesNotAdvancing.thresholdInSeconds < event.time) && !videoFramesNotAdvancingTriggered){
-                eventBus.trigger(Events.PLAYBACK_FROZEN,{cause:'Frames have stopped advancing, Chromium bug #41243192', totalVideoFrames: playbackQuality.totalVideoFrames, time: event.time });
+                eventBus.trigger(Events.PLAYBACK_FROZEN,{
+                    cause:'Frames have stopped advancing, Chromium bug #41243192',
+                    totalVideoFrames: playbackQuality.totalVideoFrames,
+                    mediaTime: event.time,
+                    isEnded: videoModel.getEnded(),
+                    isSeeking: videoModel.isSeeking()
+                });
                 if(settings.get().streaming.buffer.videoFramesNotAdvancing.enabled){
                     logger.warn('Video playback has frozen, attempting to recover by seeking to current time')
                     videoModel.setCurrentTime(videoModel.getTime()-0.0001,false)


### PR DESCRIPTION
Add additional checks to `videoFramesNotAdvancing` function. Checks that we're not at the start or end of playback. Ignores these periods. Additionally, ignores periods where the player is seeking.

Passes further information with the `PLAYBACK_FROZEN` event to aid debugging.