### PR TITLE
Video not advancing updates

### DIFF
--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -809,7 +809,7 @@ function StreamController() {
             totalVideoFramesAtLastPlaybackProgress = 0
         }
 
-        const isEnded = event.timeToEnd ? event.timeToEnd >= 0 : false;
+        const isEnded = event.timeToEnd ? event.timeToEnd <= 0 : false;
 
         const isVideoFramesNotAdvancing = playbackQuality &&
             typeof playbackQuality.totalVideoFrames === 'number'


### PR DESCRIPTION
Fixes check for `isEnded` in `videoFramesNotAdvancing` function
