### PR TITLE
Port Subtitle Changes from v4.7.4 (#4359)

### DIFF
--- a/src/streaming/text/TextTracks.js
+++ b/src/streaming/text/TextTracks.js
@@ -79,7 +79,8 @@ function TextTracks(config) {
         displayCCOnTop,
         previousISDState,
         topZIndex,
-        resizeObserver;
+        resizeObserver,
+        hasRequestAnimationFrame;
 
     function setup() {
         logger = Debug(context).getInstance().getLogger(instance);
@@ -104,6 +105,7 @@ function TextTracks(config) {
         displayCCOnTop = false;
         topZIndex = 2147483647;
         previousISDState = null;
+        hasRequestAnimationFrame = ('requestAnimationFrame' in window);
 
         if (document.fullscreenElement !== undefined) {
             fullscreenAttribute = 'fullscreenElement'; // Standard and Edge
@@ -409,20 +411,19 @@ function TextTracks(config) {
 
     function _renderCaption(cue) {
         if (captionContainer) {
+            clearCaptionContainer.call(this);
+            
             const finalCue = document.createElement('div');
             captionContainer.appendChild(finalCue);
+            
             previousISDState = renderHTML(
-                cue.isd,
-                finalCue,
-                function (src) {
-                    return _resolveImageSrc(cue, src)
-                },
-                captionContainer.clientHeight,
-                captionContainer.clientWidth,
+                cue.isd, 
+                finalCue, 
+                function (src) { return _resolveImageSrc(cue, src) }, 
+                captionContainer.clientHeight, 
+                captionContainer.clientWidth, 
                 settings.get().streaming.text.imsc.displayForcedOnlyMode,
-                function (err) {
-                    logger.info('renderCaption :', err) /*TODO: add ErrorHandler management*/
-                },
+                function (err) { logger.info('renderCaption :', err) /*TODO: add ErrorHandler management*/ },
                 previousISDState,
                 settings.get().streaming.text.imsc.enableRollUp,
                 settings.get().streaming.text.imsc.options
@@ -432,23 +433,26 @@ function TextTracks(config) {
         }
     }
 
-    function _extendLastCue(cue, track) {
+    // Check that a new cue immediately follows the previous cue
+    function _areCuesAdjacent(cue, prevCue) {
+        if (!prevCue) { 
+            return false;
+        }
+        // Check previous cue endTime with current cue startTime
+        // (should we consider an epsilon margin? for example to get around rounding issues)
+        return prevCue.endTime >= cue.startTime;
+    }
+
+    // Check if cue content is identical. If it is, extend the previous cue.
+    function _extendLastCue(cue, prevCue) {
         if (!settings.get().streaming.text.extendSegmentedCues) {
             return false;
         }
-        if (!track.cues || track.cues.length === 0) {
-            return false;
-        }
-        const prevCue = track.cues[track.cues.length - 1];
-        // Check previous cue endTime with current cue startTime
-        // (should we consider an epsilon margin? for example to get around rounding issues)
-        if (prevCue.endTime < cue.startTime) {
-            return false;
-        }
-        // Compare cues content
+
         if (!_cuesContentAreEqual(prevCue, cue, CUE_PROPS_TO_COMPARE)) {
             return false;
-        }
+        } 
+
         prevCue.endTime = Math.max(prevCue.endTime, cue.endTime);
         return true;
     }
@@ -509,7 +513,24 @@ function TextTracks(config) {
                             }
                             track.manualCueList.push(cue);
                         } else {
-                            if (!_extendLastCue(cue, track)) {
+                            // Handle adjacent cues
+                            let prevCue;
+                            if (track.cues && track.cues.length !== 0) {
+                                prevCue = track.cues[track.cues.length - 1];
+                            }
+
+                            if (_areCuesAdjacent(cue, prevCue)) {
+                                if (!_extendLastCue(cue, prevCue)) {
+                                    /* If cues are adjacent but not identical (extended), let the render function of the next cue 
+                                     * clear up the captionsContainer so removal and appending are instantaneous.
+                                     * Only do this for imsc subs (where isd is present).
+                                     */
+                                    if (prevCue.isd) {
+                                        prevCue.onexit = function () { };
+                                    }
+                                    track.addCue(cue);
+                                }
+                            } else {
                                 track.addCue(cue);
                             }
                         }
@@ -560,7 +581,12 @@ function TextTracks(config) {
         cue.onenter = function () {
             if (track.mode === Constants.TEXT_SHOWING) {
                 if (this.isd) {
-                    _renderCaption(this);
+                    if (hasRequestAnimationFrame) { 
+                        // Ensure everything in _renderCaption happens in the same frame
+                        requestAnimationFrame(() => _renderCaption(this));
+                    } else {
+                        _renderCaption(this)
+                    }
                     logger.debug('Cue enter id:' + this.cueID);
                 } else {
                     captionContainer.appendChild(this.cueHTMLElement);
@@ -573,6 +599,7 @@ function TextTracks(config) {
             }
         };
 
+        // For imsc subs, this could be reassigned to not do anything if there is a cue that immediately follows this one
         cue.onexit = function () {
             if (captionContainer) {
                 const divs = captionContainer.childNodes;


### PR DESCRIPTION
Port changes made by @mattjuggins in [#4359](https://github.com/Dash-Industry-Forum/dash.js/pull/4359) released in Dash-Industry-Forum/dash.js v4.7.4.

As seen below, the main stated aim of the PR was to resolve a flickering/blinking issues when rendering subtitles using IMSC.

This port preserves the passing of customisation options to IMSC,

> This is detailed further in issue #4358.
> 
> This is a proposed fix to prevent subtitle flickering, where the time between removal and appending of divs representing subtitle cues can have gaps in between. Using the stream in the reference player titled “[BBC] On-demand Elephant's Dream - with EBU-TT-D 'Snaking' Subtitle Track (random text) - lines grow over time simulating live subtitles”, it’s clear to see the effect before and after this code is applied.
> 
> These changes preserve the work done by @bbert in #4103 & #4155. Extending identical cues is still preserved and I have checked [the test stream mentioned in the PR](https://broadpeak-tv.github.io/test-content/dash/imsc-image/imsc1_img.mpd) still operates as expected. Additionally, this PR doesn’t affect the operation of WebVTT subtitles or CEA608 captions. The intent is to just target imsc subtitles where this flickering effect has been witnessed.
> 
> The following changes have been made:
> 
>     * Clear up the `captionsContainer` immediately before adding new elements in `_renderCaption()`.
> 
>     * Use requestAnimationFrame (where available) for performance benefits and to ensure drawing as a cause of `_renderCaption()` happens in the same frame (it should if not available anyway now).
> 
>     * If cues are adjacent, and not identical, make sure they are cleaned up within `_renderCaption()` and not at a different time by the `onexit` event. Ensure this only happens for imsc subs.
> 
>     * Refactor around `_extendLastCue()` for clarity.
> 
>     * Separate out arguments for the imscJS `renderHTML` function, for readability. I have not changed the arguments, just the formatting.