### PR TITLE
DVB Reporting Override

### DIFF
--- a/dash.d.ts
+++ b/dash.d.ts
@@ -1157,6 +1157,9 @@ declare namespace dashjs {
                 mode?: 'query' | 'header',
                 enabledKeys?: Array<string>
             },
+            dvbReporting?: {
+                reportingUrl?: string | null,
+            }
             cmsd?: {
                 enabled?: boolean,
                 abr?: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1157,6 +1157,9 @@ declare namespace dashjs {
                 mode?: 'query' | 'header',
                 enabledKeys?: Array<string>
             },
+            dvbReporting?: {
+                reportingUrl?: string | null,
+            }
             cmsd?: {
                 enabled?: boolean,
                 abr?: {

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -247,6 +247,9 @@ import Events from './events/Events';
  *                mode: Constants.CMCD_MODE_QUERY,
  *                enabledKeys: ['br', 'd', 'ot', 'tb' , 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su' , 'bs', 'rtp' , 'cid', 'pr', 'sf', 'sid', 'st', 'v']
  *            },
+ *            dvbReporting: {
+ *                reportingUrl: null,
+ *            },
  *            cmsd: {
  *                enabled: false,
  *                abr: {
@@ -784,6 +787,12 @@ import Events from './events/Events';
  */
 
 /**
+ * @typedef {Object} module:Settings~DvbReportingSettings
+ * @property {string} [reportingUrl]
+ * Overide DVB reporting url.
+ */
+
+/**
  * @typedef {Object} module:Settings~CmsdSettings
  * @property {boolean} [enabled=false]
  * Enable or disable the CMSD response headers parsing.
@@ -913,6 +922,8 @@ import Events from './events/Events';
  * @property {module:Settings~AbrSettings} abr
  * Adaptive Bitrate algorithm related settings.
  * @property {module:Settings~CmcdSettings} cmcd
+ * Settings related to Common Media Client Data reporting.
+ * @property {module:Settings~DvbReportingSettings} dvbReporting
  * Settings related to Common Media Client Data reporting.
  * @property {module:Settings~CmsdSettings} cmsd
  * Settings related to Common Media Server Data parsing.
@@ -1178,6 +1189,9 @@ function Settings() {
                 rtpSafetyFactor: 5,
                 mode: Constants.CMCD_MODE_QUERY,
                 enabledKeys: ['br', 'd', 'ot', 'tb', 'bl', 'dl', 'mtp', 'nor', 'nrr', 'su', 'bs', 'rtp', 'cid', 'pr', 'sf', 'sid', 'st', 'v']
+            },
+            dvbReporting: {
+                reportingUrl: null,
             },
             cmsd: {
                 enabled: false,

--- a/src/streaming/metrics/controllers/MetricsController.js
+++ b/src/streaming/metrics/controllers/MetricsController.js
@@ -54,7 +54,8 @@ function MetricsController(config) {
             reportingController = ReportingController(context).create({
                 debug: config.debug,
                 metricsConstants: config.metricsConstants,
-                mediaPlayerModel: config.mediaPlayerModel
+                mediaPlayerModel: config.mediaPlayerModel,
+                settings: config.settings
             });
 
             reportingController.initialize(metricsEntry.Reporting, rangeController);

--- a/src/streaming/metrics/controllers/MetricsController.js
+++ b/src/streaming/metrics/controllers/MetricsController.js
@@ -55,7 +55,6 @@ function MetricsController(config) {
                 debug: config.debug,
                 metricsConstants: config.metricsConstants,
                 mediaPlayerModel: config.mediaPlayerModel,
-                settings: config.settings
             });
 
             reportingController.initialize(metricsEntry.Reporting, rangeController);

--- a/src/streaming/metrics/controllers/MetricsController.js
+++ b/src/streaming/metrics/controllers/MetricsController.js
@@ -53,8 +53,7 @@ function MetricsController(config) {
 
             reportingController = ReportingController(context).create({
                 debug: config.debug,
-                metricsConstants: config.metricsConstants,
-                mediaPlayerModel: config.mediaPlayerModel,
+                metricsConstants: config.metricsConstants
             });
 
             reportingController.initialize(metricsEntry.Reporting, rangeController);

--- a/src/streaming/metrics/reporting/ReportingFactory.js
+++ b/src/streaming/metrics/reporting/ReportingFactory.js
@@ -50,7 +50,8 @@ function ReportingFactory(config) {
         try {
             reporting = knownReportingSchemeIdUris[entry.schemeIdUri](context).create({
                 metricsConstants: metricsConstants,
-                mediaPlayerModel: mediaPlayerModel
+                mediaPlayerModel: mediaPlayerModel,
+                settings: config.settings
             });
 
             reporting.initialize(entry, rangeController);

--- a/src/streaming/metrics/reporting/ReportingFactory.js
+++ b/src/streaming/metrics/reporting/ReportingFactory.js
@@ -50,8 +50,7 @@ function ReportingFactory(config) {
         try {
             reporting = knownReportingSchemeIdUris[entry.schemeIdUri](context).create({
                 metricsConstants: metricsConstants,
-                mediaPlayerModel: mediaPlayerModel,
-                settings: config.settings
+                mediaPlayerModel: mediaPlayerModel
             });
 
             reporting.initialize(entry, rangeController);

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -32,7 +32,7 @@
 import MetricSerialiser from '../../utils/MetricSerialiser';
 import RNG from '../../utils/RNG';
 import CustomParametersModel from '../../../models/CustomParametersModel';
-
+import Settings from '../../../../core/Settings';
 function DVBReporting(config) {
     config = config || {};
     let instance;
@@ -45,7 +45,7 @@ function DVBReporting(config) {
         isReportingPlayer,
         reportingUrl,
         rangeController,
-        settings;
+        settings = Settings(context).getInstance();
 
     let USE_DRAFT_DVB_SPEC = true;
     let allowPendingRequestsToCompleteOnReset = true;
@@ -175,9 +175,6 @@ function DVBReporting(config) {
         isReportingPlayer = false;
         reportingUrl = null;
         rangeController = null;
-        if (config.settings) {
-            settings = config.settings;
-        }
     }
 
     function reset() {

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -142,7 +142,7 @@ function DVBReporting(config) {
 
         rangeController = rc;
 
-        reportingUrl = settings.get().dvbReporting.reportingUrl || entry.dvb_reportingUrl;
+        reportingUrl = settings.get().streaming.dvbReporting.reportingUrl || entry.dvb_reportingUrl;
 
         // If a required attribute is missing, the Reporting descriptor may
         // be ignored by the Player

--- a/src/streaming/metrics/reporting/reporters/DVBReporting.js
+++ b/src/streaming/metrics/reporting/reporters/DVBReporting.js
@@ -44,7 +44,8 @@ function DVBReporting(config) {
         reportingPlayerStatusDecided,
         isReportingPlayer,
         reportingUrl,
-        rangeController;
+        rangeController,
+        settings;
 
     let USE_DRAFT_DVB_SPEC = true;
     let allowPendingRequestsToCompleteOnReset = true;
@@ -141,13 +142,13 @@ function DVBReporting(config) {
 
         rangeController = rc;
 
-        reportingUrl = entry.dvb_reportingUrl;
+        reportingUrl = settings.get().dvbReporting.reportingUrl || entry.dvb_reportingUrl;
 
         // If a required attribute is missing, the Reporting descriptor may
         // be ignored by the Player
         if (!reportingUrl) {
             throw new Error(
-                'required parameter missing (dvb:reportingUrl)'
+                'MPD parameter missing "dvb:reportingUrl" or URL not given in settings'
             );
         }
 
@@ -174,6 +175,9 @@ function DVBReporting(config) {
         isReportingPlayer = false;
         reportingUrl = null;
         rangeController = null;
+        if (config.settings) {
+            settings = config.settings;
+        }
     }
 
     function reset() {


### PR DESCRIPTION
📺 What

Adds a new setting - `dvbReporting.reportingUrl`. This allows Dash.js to manually override the DVB metrics reporting URL provided in the manifest. 

Useful for moving away from dynamic manifest in use for the low latency trial. A URL containing a session UUID can be formed on the client and passed directly to Dash.js on initialisation.

🛠 How

New setting is checked when DVB reporter is set up in Dash.js. If set, the URL provided in the setting is used over any URL already in the manifest.