### PR TITLE
BADGER-260 Add Artificial Time Offset

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1020,7 +1020,8 @@ declare namespace dashjs {
                 defaultTimingSource?: {
                     scheme?: string,
                     value?: string
-                }
+                },
+                artificialTimeOffsetToApply?: number
             },
             scheduling?: {
                 defaultTimeout?: number,

--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -145,7 +145,8 @@ import Events from './events/Events';
  *                defaultTimingSource: {
  *                    scheme: 'urn:mpeg:dash:utc:http-xsdate:2014',
  *                    value: 'http://time.akamai.com/?iso&ms'
- *                }
+ *                },
+ *                artificialTimeOffsetToApply: 0
  *            },
  *            scheduling: {
  *                defaultTimeout: 500,
@@ -506,6 +507,9 @@ import Events from './events/Events';
  *
  * @property {object} [defaultTimingSource={scheme:'urn:mpeg:dash:utc:http-xsdate:2014',value: 'http://time.akamai.com/?iso&ms'}]
  * The default timing source to be used. The timing sources in the MPD take precedence over this one.
+ * 
+ * @property {number} [artificialTimeOffsetToApply=0]
+ * The offset defined in milliseconds that is applied on top of the offset that was derived after the time synchronization.
  */
 
 /**
@@ -1034,7 +1038,8 @@ function Settings() {
                 defaultTimingSource: {
                     scheme: 'urn:mpeg:dash:utc:http-xsdate:2014',
                     value: 'https://time.akamai.com/?iso&ms'
-                }
+                },
+                artificialTimeOffsetToApply: 0,
             },
             scheduling: {
                 defaultTimeout: 500,

--- a/src/streaming/controllers/TimeSyncController.js
+++ b/src/streaming/controllers/TimeSyncController.js
@@ -552,8 +552,9 @@ function TimeSyncController() {
         }
 
         // Notify other classes
+        const artificialTimeOffsetToApply = settings.get().streaming.utcSynchronization.artificialTimeOffsetToApply;
         eventBus.trigger(Events.UPDATE_TIME_SYNC_OFFSET, {
-            offset: offset,
+            offset: offset + artificialTimeOffsetToApply,
         });
         eventBus.trigger(Events.TIME_SYNCHRONIZATION_COMPLETED);
     }


### PR DESCRIPTION
Mirrors https://github.com/Dash-Industry-Forum/dash.js/pull/4887 in Dash.js v5.

This adds the ability to specify an extra time offset for UTC Time Synchronisation. In our case, this can be used to add a jitter for segment requests - preventing thundering heards at the CDN end.

> Ticket: https://bbc.atlassian.net/browse/BADGER-260