### PR TITLE
Account for other sync events from the `TimeSyncController`

### DIFF
--- a/src/streaming/controllers/TimeSyncController.js
+++ b/src/streaming/controllers/TimeSyncController.js
@@ -600,8 +600,9 @@ function TimeSyncController() {
         if (!_isOffsetDriftWithinThreshold(averageOffset)) {
             logger.debug(`Completed background UTC sync. Setting client - server offset to ${averageOffset}`);
             lastOffset = averageOffset;
+            const artificialTimeOffsetToApply = settings.get().streaming.utcSynchronization.artificialTimeOffsetToApply;
             eventBus.trigger(Events.UPDATE_TIME_SYNC_OFFSET, {
-                offset: lastOffset
+                offset: artificialTimeOffsetToApply + lastOffset
             });
         } else {
             logger.debug(`Completed background UTC sync. Offset is within allowed threshold and is not adjusted.`);


### PR DESCRIPTION

Leaving some useful debugging code here that can be added to the `XHRLoader` at the top of the `request` function (Line 60). That help demonstrate whether the timeline has actually moved.

```js
        if(httpRequest.url.includes('m4s')){
            const urlParts = httpRequest.url.split('/')
            const segmentWithExt = urlParts[urlParts.length-1]
            const segment = Number(segmentWithExt.split('.')[0])
            console.log(`TIME: Request delta ${(requestStartTime.getTime() -(segment*3840) - 2500)/1000}s`)
        }
```

### Before the change

With `liveDelay` set to 12s and `artificialTimeOffsetToApply` -5000ms.

```
TIME: Offset -59.75ms
PlaybackController.js:404 TIME: Offset -59.75ms
XHRLoader.js:66 TIME: Request delta 22.924s
XHRLoader.js:66 TIME: Request delta 23.062s
```

Note, only appears to happen on the first load of the player. Subsequent “loads” of the reference player results in the expected behaviour. Looks like this could be a race condition on which `UPDATE_TIME_SYNC_OFFSET` triggers first.

### After the change

With `liveDelay` set to 12s and `artificialTimeOffsetToApply` -5000ms.

```
TIME: Offset -5134.5ms
XHRLoader.js:66 TIME: Request delta 27.986s
XHRLoader.js:66 TIME: Request delta 28.132s
```
