### PR TITLE
Remove experimental maxDecoderRate

### DIFF
--- a/src/core/Settings.js
+++ b/src/core/Settings.js
@@ -76,8 +76,7 @@ import Events from './events/Events';
  *            },
  *            timeShiftBuffer: {
  *                calcFromSegmentTimeline: false,
- *                fallbackToSegmentTimeline: true,
- *                maxDecoderRate: NaN
+ *                fallbackToSegmentTimeline: true
  *            },
  *            metrics: {
  *              maxListDepth: 100
@@ -269,8 +268,6 @@ import Events from './events/Events';
  * Enable calculation of the DVR window for SegmentTimeline manifests based on the entries in \<SegmentTimeline\>.
  * @property {boolean} [fallbackToSegmentTimeline=true]
  * In case the MPD uses \<SegmentTimeline\ and no segment is found within the DVR window the DVR window is calculated based on the entries in \<SegmentTimeline\>.
- * @property {number} [maxDecoderRate=NaN]
- * The maximum rate your decoder can run at, can be used to overshoot the startup seek in anticpation of delay in hardware e.g.) TVs
 */
 
 /**
@@ -972,8 +969,7 @@ function Settings() {
             },
             timeShiftBuffer: {
                 calcFromSegmentTimeline: false,
-                fallbackToSegmentTimeline: true,
-                maxDecoderRate: null
+                fallbackToSegmentTimeline: true
             },
             metrics: {
                 maxListDepth: 100

--- a/src/streaming/controllers/StreamController.js
+++ b/src/streaming/controllers/StreamController.js
@@ -1117,19 +1117,6 @@ function StreamController() {
                 // If calcFromSegmentTimeline is enabled we saw problems caused by the MSE.seekableRange when starting at dvrWindow.start. Apply a small offset to avoid this problem.
                 const offset = settings.get().streaming.timeShiftBuffer.calcFromSegmentTimeline ? 0.1 : 0;
                 startTime = Math.max(startTime, dvrWindow.start + offset);
-
-                // In hardware playback use optional maxDecoderRate setting to compensate for startup delay
-                const maxDecoderRate = settings.get().streaming.timeShiftBuffer.maxDecoderRate;
-                if(maxDecoderRate && !isNaN(maxDecoderRate)){
-                    const seektime = liveEdge - playbackController.getOriginalLiveDelay();
-                    const segmentDuration = streams[0].getStreamInfo().manifestInfo.maxFragmentDuration;
-                    const seektimeQuantised = segmentDuration * (1 + parseInt(seektime / segmentDuration))
-                    const positionInSegment = seektimeQuantised - seektime
-
-                    logger.info(`Overshoot start seek by ${positionInSegment/maxDecoderRate} to compensate for decoder.`);
-                    startTime += positionInSegment/maxDecoderRate
-                }
-
             }
         } else {
             // For static stream, start by default at period start


### PR DESCRIPTION
Removes experimental code that isn't used but should not be released.

Introduced by an accidental push directly to `smp-v4.7` (May 2025)  and subsequently incorporated in a later release (Aug 25).

Code path is unused unless a setting is passed to the player so has never been used.